### PR TITLE
Don't update simulation time with cancelled event

### DIFF
--- a/crates/simcore/src/state.rs
+++ b/crates/simcore/src/state.rs
@@ -66,8 +66,8 @@ impl SimulationState {
     pub fn next_event(&mut self) -> Option<Event> {
         loop {
             if let Some(event) = self.events.pop() {
-                self.clock = event.time;
                 if !self.canceled_events.remove(&event.id) {
+                    self.clock = event.time;
                     return Some(event);
                 }
             } else {


### PR DESCRIPTION
(псевдокод)
```rust
let id = sim.emit(5., Start{});
sim.cancel_event(id);
sim.step_until_no_events();
eprintln!("{}", sim.time());  // 5
sim.emit(0., Start{});  // отправляется в момент времени 5, хотя по факту событий в симуляции не было
```