### PR TITLE
Allow dead code in unused fair_slow model

### DIFF
--- a/crates/dslab-models/src/throughput_sharing/fair_slow.rs
+++ b/crates/dslab-models/src/throughput_sharing/fair_slow.rs
@@ -1,6 +1,8 @@
 //! Slow implementation of fair throughput sharing model, which recalculates all event times at each activity creation
 //! and completion.
 
+#![allow(dead_code)]
+
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 


### PR DESCRIPTION
Надо либо заиспользовать модель где-то (или хотя бы сделать pub mod), либо разрешить неиспользуемый код, чтобы ворнингов не было