### PR TITLE
[faas] Improved experiment generation

### DIFF
--- a/crates/dslab-faas/Cargo.toml
+++ b/crates/dslab-faas/Cargo.toml
@@ -13,7 +13,8 @@ indexmap = "1.8.2"
 itertools = "0.10.3"
 num = "0.2.0"
 order-stat = "0.1.3"
-rand = "0.8"
+rand = { version = "0.8", features = ["alloc"] }
+rand_distr = "0.4.3"
 rand_pcg = "0.3.1"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/dslab-faas/Cargo.toml
+++ b/crates/dslab-faas/Cargo.toml
@@ -13,7 +13,7 @@ indexmap = "1.8.2"
 itertools = "0.10.3"
 num = "0.2.0"
 order-stat = "0.1.3"
-rand = { version = "0.8", features = ["alloc"] }
+rand = { version = "0.8.5", features = ["alloc"] }
 rand_distr = "0.4.3"
 rand_pcg = "0.3.1"
 rustc-hash = "1.1.0"

--- a/crates/dslab-faas/src/config.rs
+++ b/crates/dslab-faas/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::coldstart::{default_coldstart_policy_resolver, ColdStartPolicy, FixedTimeColdStartPolicy};
 use crate::deployer::{default_idle_deployer_resolver, BasicDeployer, IdleDeployer};
-use crate::invoker::{default_invoker_resolver, BasicInvoker, Invoker};
+use crate::invoker::{default_invoker_resolver, FIFOInvoker, Invoker};
 use crate::parallel::{ParallelConfig, ParallelHostConfig};
 use crate::scheduler::{default_scheduler_resolver, BasicScheduler, Scheduler};
 
@@ -30,7 +30,7 @@ impl From<ParallelHostConfig> for HostConfig {
 impl Default for HostConfig {
     fn default() -> Self {
         Self {
-            invoker: Box::new(BasicInvoker::new()),
+            invoker: Box::new(FIFOInvoker::new()),
             resources: Vec::new(),
             cores: 1,
         }
@@ -175,7 +175,7 @@ impl Config {
                 let invoker = if !host.invoker.is_empty() {
                     invoker_resolver(&host.invoker)
                 } else {
-                    Box::new(BasicInvoker::new())
+                    Box::new(FIFOInvoker::new())
                 };
                 let curr = HostConfig {
                     invoker,

--- a/crates/dslab-faas/src/config.rs
+++ b/crates/dslab-faas/src/config.rs
@@ -131,7 +131,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(0.0, 0.0)),
-            cpu_policy: Box::new(ContendedCPUPolicy::default()),
+            cpu_policy: Box::<ContendedCPUPolicy>::default(),
             idle_deployer: Box::new(BasicDeployer {}),
             scheduler: Box::new(BasicScheduler {}),
             hosts: Vec::new(),

--- a/crates/dslab-faas/src/config.rs
+++ b/crates/dslab-faas/src/config.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::coldstart::{default_coldstart_policy_resolver, ColdStartPolicy, FixedTimeColdStartPolicy};
-use crate::cpu::{default_cpu_policy_resolver, CpuPolicy, ContendedCpuPolicy};
+use crate::cpu::{default_cpu_policy_resolver, ContendedCpuPolicy, CpuPolicy};
 use crate::deployer::{default_idle_deployer_resolver, BasicDeployer, IdleDeployer};
 use crate::invoker::{default_invoker_resolver, FIFOInvoker, Invoker};
 use crate::parallel::{ParallelConfig, ParallelHostConfig};

--- a/crates/dslab-faas/src/config.rs
+++ b/crates/dslab-faas/src/config.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::coldstart::{default_coldstart_policy_resolver, ColdStartPolicy, FixedTimeColdStartPolicy};
-use crate::cpu::{default_cpu_policy_resolver, CPUPolicy, ContendedCPUPolicy};
+use crate::cpu::{default_cpu_policy_resolver, CpuPolicy, ContendedCpuPolicy};
 use crate::deployer::{default_idle_deployer_resolver, BasicDeployer, IdleDeployer};
 use crate::invoker::{default_invoker_resolver, FIFOInvoker, Invoker};
 use crate::parallel::{ParallelConfig, ParallelHostConfig};
@@ -99,7 +99,7 @@ pub fn parse_options(s: &str) -> HashMap<String, String> {
 
 pub struct ConfigParamResolvers {
     pub coldstart_policy_resolver: Box<dyn Fn(&str) -> Box<dyn ColdStartPolicy> + Send + Sync>,
-    pub cpu_policy_resolver: Box<dyn Fn(&str) -> Box<dyn CPUPolicy> + Send + Sync>,
+    pub cpu_policy_resolver: Box<dyn Fn(&str) -> Box<dyn CpuPolicy> + Send + Sync>,
     pub idle_deployer_resolver: Box<dyn Fn(&str) -> Box<dyn IdleDeployer> + Send + Sync>,
     pub scheduler_resolver: Box<dyn Fn(&str) -> Box<dyn Scheduler> + Send + Sync>,
     pub invoker_resolver: Box<dyn Fn(&str) -> Box<dyn Invoker> + Send + Sync>,
@@ -121,7 +121,7 @@ impl Default for ConfigParamResolvers {
 /// default config and change only the fields you need.
 pub struct Config {
     pub coldstart_policy: Box<dyn ColdStartPolicy>,
-    pub cpu_policy: Box<dyn CPUPolicy>,
+    pub cpu_policy: Box<dyn CpuPolicy>,
     pub idle_deployer: Box<dyn IdleDeployer>,
     pub scheduler: Box<dyn Scheduler>,
     pub hosts: Vec<HostConfig>,
@@ -131,7 +131,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(0.0, 0.0)),
-            cpu_policy: Box::<ContendedCPUPolicy>::default(),
+            cpu_policy: Box::<ContendedCpuPolicy>::default(),
             idle_deployer: Box::new(BasicDeployer {}),
             scheduler: Box::new(BasicScheduler {}),
             hosts: Vec::new(),
@@ -154,7 +154,7 @@ impl Config {
     pub fn from_raw_split_resolvers(
         raw: RawConfig,
         coldstart_policy_resolver: &(dyn Fn(&str) -> Box<dyn ColdStartPolicy> + Send + Sync),
-        cpu_policy_resolver: &(dyn Fn(&str) -> Box<dyn CPUPolicy> + Send + Sync),
+        cpu_policy_resolver: &(dyn Fn(&str) -> Box<dyn CpuPolicy> + Send + Sync),
         idle_deployer_resolver: &(dyn Fn(&str) -> Box<dyn IdleDeployer> + Send + Sync),
         scheduler_resolver: &(dyn Fn(&str) -> Box<dyn Scheduler> + Send + Sync),
         invoker_resolver: &(dyn Fn(&str) -> Box<dyn Invoker> + Send + Sync),

--- a/crates/dslab-faas/src/cpu.rs
+++ b/crates/dslab-faas/src/cpu.rs
@@ -262,7 +262,7 @@ impl CPUPolicy for ContendedCPUPolicy {
         invocation: &mut Invocation,
         container: &mut Container,
         time: f64,
-        ctx: &mut SimulationContext
+        ctx: &mut SimulationContext,
     ) {
         self.shift_time(time);
         if container.invocations.len() > 1 {

--- a/crates/dslab-faas/src/cpu.rs
+++ b/crates/dslab-faas/src/cpu.rs
@@ -108,7 +108,7 @@ impl CPUPolicy for IgnoredCPUPolicy {
 
 /// CPU shares of active containers should not exceed the number of cores. If this limit is
 /// exceeded, extra invocations are stalled until some cores are freed.
-/// This model ignores possible effects related to multiple concurrent invocations on the same
+/// This model currently ignores possible effects related to multiple concurrent invocations on the same
 /// container.
 #[derive(Default)]
 pub struct IsolatedCPUPolicy {

--- a/crates/dslab-faas/src/cpu.rs
+++ b/crates/dslab-faas/src/cpu.rs
@@ -2,10 +2,10 @@
 /// We use something similar to CPUShares in cgroups, but instead of shares we operate with (shares/core_shares),
 /// i. e. if the container has 512 shares and each core amounts to 1024 shares, we say that the share of the container equals 0.5.
 /// If the container allows concurrent invocations, each invocation gets an equal part of the container share.
-/// We assume that CPU sharing is fair: each invocation makes progress according to its share.
+/// The exact CPU model depends on the CPUPolicy chosen.
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::rc::Rc;
 
 use dslab_core::context::SimulationContext;
@@ -41,9 +41,148 @@ impl Ord for WorkItem {
     }
 }
 
-/// ProgressComputer computes invocation progress and manages invocation end events.
-pub struct ProgressComputer {
-    disable_contention: bool,
+/// CPUPolicy governs CPU sharing, computes invocation progress and manages invocation end events.
+pub trait CPUPolicy {
+    fn clean_copy(&self) -> Box<dyn CPUPolicy>;
+    fn get_load(&self) -> f64;
+    fn set_cores(&mut self, cores: f64);
+    fn on_invocation_end(
+        &mut self,
+        invocation: &mut Invocation,
+        container: &mut Container,
+        time: f64,
+        ctx: &mut SimulationContext,
+    );
+    fn on_new_invocation(
+        &mut self,
+        invocation: &mut Invocation,
+        container: &mut Container,
+        time: f64,
+        ctx: &mut SimulationContext,
+    );
+}
+
+/// This policy does not emulate CPU at all. All invocations work as if executed on some abstract
+/// infinite-core CPU with no load issues.
+#[derive(Default)]
+pub struct IgnoredCPUPolicy {
+    load: f64,
+}
+
+impl CPUPolicy for IgnoredCPUPolicy {
+    fn clean_copy(&self) -> Box<dyn CPUPolicy> {
+        Box::new(Self::default())
+    }
+
+    fn get_load(&self) -> f64 {
+        self.load
+    }
+
+    fn set_cores(&mut self, _cores: f64) {}
+
+    fn on_invocation_end(
+        &mut self,
+        _invocation: &mut Invocation,
+        container: &mut Container,
+        _time: f64,
+        _ctx: &mut SimulationContext,
+    ) {
+        if container.invocations.is_empty() {
+            self.load -= container.cpu_share;
+        }
+    }
+
+    fn on_new_invocation(
+        &mut self,
+        invocation: &mut Invocation,
+        container: &mut Container,
+        _time: f64,
+        ctx: &mut SimulationContext,
+    ) {
+        if container.invocations.len() == 1 {
+            self.load += container.cpu_share;
+        }
+        ctx.emit_self(InvocationEndEvent { id: invocation.id }, invocation.duration);
+    }
+}
+
+/// CPU shares of active containers should not exceed the number of cores. If this limit is
+/// exceeded, extra invocations are stalled until some cores are freed.
+/// This model ignores possible effects related to multiple concurrent invocations on the same
+/// container.
+#[derive(Default)]
+pub struct IsolatedCPUPolicy {
+    cores: f64,
+    load: f64,
+    invocation_map: HashMap<usize, Vec<(usize, f64)>>,
+    queue: VecDeque<(usize, f64)>,
+}
+
+impl CPUPolicy for IsolatedCPUPolicy {
+    fn clean_copy(&self) -> Box<dyn CPUPolicy> {
+        Box::new(Self::default())
+    }
+
+    fn get_load(&self) -> f64 {
+        self.load
+    }
+
+    fn set_cores(&mut self, cores: f64) {
+        self.cores = cores;
+    }
+
+    fn on_invocation_end(
+        &mut self,
+        _invocation: &mut Invocation,
+        container: &mut Container,
+        _time: f64,
+        ctx: &mut SimulationContext,
+    ) {
+        if container.invocations.is_empty() {
+            self.load -= container.cpu_share;
+            while let Some(item) = self.queue.pop_front() {
+                if self.load + item.1 > self.cores + 1e-9 {
+                    self.queue.push_front(item);
+                    break;
+                }
+                self.load += item.1;
+                let mut invs = self.invocation_map.remove(&item.0).unwrap();
+                for inv in invs.drain(..) {
+                    ctx.emit_self(InvocationEndEvent { id: inv.0 }, inv.1);
+                }
+            }
+        }
+    }
+
+    fn on_new_invocation(
+        &mut self,
+        invocation: &mut Invocation,
+        container: &mut Container,
+        _time: f64,
+        ctx: &mut SimulationContext,
+    ) {
+        if let Some(invs) = self.invocation_map.get_mut(&container.id) {
+            invs.push((invocation.id, invocation.duration));
+        } else {
+            if container.invocations.len() == 1 && self.load + container.cpu_share > self.cores + 1e-9 {
+                self.invocation_map
+                    .insert(container.id, vec![(invocation.id, invocation.duration)]);
+                self.queue.push_back((container.id, container.cpu_share));
+            } else {
+                if container.invocations.len() == 1 {
+                    self.load += container.cpu_share;
+                }
+                ctx.emit_self(InvocationEndEvent { id: invocation.id }, invocation.duration);
+            }
+        }
+    }
+}
+
+/// CPU shares of active containers may exceed the number of cores, in this case the
+/// invocations are slowed down.
+/// We assume that CPU sharing is fair: each invocation makes progress according to its share.
+#[derive(Default)]
+pub struct ContendedCPUPolicy {
     work_tree: BTreeSet<WorkItem>,
     work_map: HashMap<usize, WorkItem>,
     work_total: f64,
@@ -51,14 +190,9 @@ pub struct ProgressComputer {
     load: f64,
     last_update: f64,
     end_event: Option<EventId>,
-    ctx: Rc<RefCell<SimulationContext>>,
 }
 
-impl ProgressComputer {
-    pub fn get_load(&self) -> f64 {
-        self.load
-    }
-
+impl ContendedCPUPolicy {
     fn try_rebuild(&mut self) {
         if self.work_total > 1e12 {
             let mut items: Vec<_> = self.work_tree.iter().cloned().collect();
@@ -75,14 +209,14 @@ impl ProgressComputer {
         }
     }
 
-    fn reschedule_end(&mut self) {
+    fn reschedule_end(&mut self, ctx: &mut SimulationContext) {
         if let Some(evt) = self.end_event {
-            self.ctx.borrow_mut().cancel_event(evt);
+            ctx.cancel_event(evt);
         }
         if !self.work_tree.is_empty() {
             let it = self.work_tree.iter().next().unwrap().clone();
             let delta = (it.finish - self.work_total).max(0.);
-            self.end_event = Some(self.ctx.borrow_mut().emit_self(
+            self.end_event = Some(ctx.emit_self(
                 InvocationEndEvent { id: it.id },
                 delta * f64::max(self.cores, self.load),
             ));
@@ -110,14 +244,28 @@ impl ProgressComputer {
         self.work_total += (time - self.last_update) / f64::max(self.cores, self.load);
         self.try_rebuild();
     }
+}
 
-    fn on_new_invocation(&mut self, invocation: &mut Invocation, container: &mut Container, time: f64) {
-        if self.disable_contention {
-            self.ctx
-                .borrow_mut()
-                .emit_self(InvocationEndEvent { id: invocation.id }, invocation.duration);
-            return;
-        }
+impl CPUPolicy for ContendedCPUPolicy {
+    fn clean_copy(&self) -> Box<dyn CPUPolicy> {
+        Box::new(Self::default())
+    }
+
+    fn get_load(&self) -> f64 {
+        self.load
+    }
+
+    fn set_cores(&mut self, cores: f64) {
+        self.cores = cores;
+    }
+
+    fn on_new_invocation(
+        &mut self,
+        invocation: &mut Invocation,
+        container: &mut Container,
+        time: f64,
+        ctx: &mut SimulationContext
+    ) {
         self.shift_time(time);
         if container.invocations.len() > 1 {
             let cnt = container.invocations.len() as f64;
@@ -135,13 +283,16 @@ impl ProgressComputer {
             invocation.duration / self.cores * (container.invocations.len() as f64),
         );
         self.last_update = time;
-        self.reschedule_end();
+        self.reschedule_end(ctx);
     }
 
-    fn on_invocation_end(&mut self, invocation: &mut Invocation, container: &mut Container, time: f64) {
-        if self.disable_contention {
-            return;
-        }
+    fn on_invocation_end(
+        &mut self,
+        invocation: &mut Invocation,
+        container: &mut Container,
+        time: f64,
+        ctx: &mut SimulationContext,
+    ) {
         self.end_event = None;
         self.shift_time(time);
         self.remove_invocation(invocation.id);
@@ -155,43 +306,46 @@ impl ProgressComputer {
             self.load -= container.cpu_share;
         }
         self.last_update = time;
-        self.reschedule_end();
+        self.reschedule_end(ctx);
+    }
+}
+
+pub fn default_cpu_policy_resolver(s: &str) -> Box<dyn CPUPolicy> {
+    let lower = s.to_lowercase();
+    if lower == "ignored" {
+        Box::new(IgnoredCPUPolicy::default())
+    } else if lower == "isolated" {
+        Box::new(IsolatedCPUPolicy::default())
+    } else if lower == "contended" {
+        Box::new(ContendedCPUPolicy::default())
+    } else {
+        panic!("Can't resolve: {}", s);
     }
 }
 
 pub struct CPU {
     pub cores: u32,
-    progress_computer: ProgressComputer,
+    policy: Box<dyn CPUPolicy>,
+    ctx: Rc<RefCell<SimulationContext>>,
 }
 
 impl CPU {
-    pub fn new(cores: u32, disable_contention: bool, ctx: Rc<RefCell<SimulationContext>>) -> Self {
-        let progress_computer = ProgressComputer {
-            disable_contention,
-            work_tree: Default::default(),
-            work_map: Default::default(),
-            work_total: Default::default(),
-            cores: cores as f64,
-            load: Default::default(),
-            last_update: 0.,
-            end_event: None,
-            ctx,
-        };
-        Self {
-            cores,
-            progress_computer,
-        }
+    pub fn new(cores: u32, mut policy: Box<dyn CPUPolicy>, ctx: Rc<RefCell<SimulationContext>>) -> Self {
+        policy.set_cores(cores as f64);
+        Self { cores, policy, ctx }
     }
 
     pub fn get_load(&self) -> f64 {
-        self.progress_computer.get_load()
+        self.policy.get_load()
     }
 
     pub fn on_new_invocation(&mut self, invocation: &mut Invocation, container: &mut Container, time: f64) {
-        self.progress_computer.on_new_invocation(invocation, container, time)
+        self.policy
+            .on_new_invocation(invocation, container, time, &mut self.ctx.borrow_mut())
     }
 
     pub fn on_invocation_end(&mut self, invocation: &mut Invocation, container: &mut Container, time: f64) {
-        self.progress_computer.on_invocation_end(invocation, container, time)
+        self.policy
+            .on_invocation_end(invocation, container, time, &mut self.ctx.borrow_mut())
     }
 }

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -457,6 +457,14 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
                 }
             }
         }
+        // it's possible that some functions don't have a record in duration file
+        // in this case we use Lognormal(-0.38, 2.36) distribution
+        let dist = LogNormal::new(-0.38, 2.36).unwrap();
+        for inv in invocations.iter_mut() {
+            if inv.2 == 0. {
+                inv.2 = f64::max(0.001, dist.sample(&mut gen));
+            }
+        }
     }
     let mut app_records: Vec<ApplicationRecord> = vec![Default::default(); apps.len()];
     let mut func_records: Vec<FunctionRecord> = vec![Default::default(); fn_id.len()];

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -1,12 +1,13 @@
 /// This file contains functions responsible for parsing Azure functions trace.
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use csv::ReaderBuilder;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use rand::prelude::*;
+use rand_distr::{Distribution, LogNormal};
 use rand_pcg::Pcg64;
 
 use crate::trace::{ApplicationData, RequestData, Trace};
@@ -100,9 +101,51 @@ fn app_id(id: &str) -> String {
     id0
 }
 
+/// Experiment generator will choose `count` random apps with popularity in range [floor(`left` * n_apps), floor(`right` * n_apps)] (less = more popular).
+pub struct AppPreference {
+    pub count: usize,
+    pub left: f64,
+    pub right: f64,
+}
+
+impl AppPreference {
+    pub fn new(count: usize, left: f64, right: f64) -> Self {
+        Self { count, left, right }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if !(0. ..1.).contains(&self.left) {
+            return Err(format!("left position {} out of range [0, 1)", self.left));
+        }
+        if !(0. ..1.).contains(&self.right) {
+            return Err(format!("right position {} out of range [0, 1)", self.right));
+        }
+        if self.left > self.right {
+            return Err(format!(
+                "left position {} greater than right position {}",
+                self.left, self.right
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub enum DurationGenerator {
+    /// Simple duration generator from quantiles.
+    Piecewise,
+    /// Generate duration from Lognormal(-0.38, 2.36).
+    PrefittedLognormal,
+    /// Generate duration from Lognormal distribution fitted to each function separately.
+    Lognormal,
+}
+
 pub struct AzureTraceConfig {
-    pub invocations_limit: usize,
+    /// Simulation time period in minutes (only integer numbers are supported).
+    pub time_period: u64,
+    pub duration_generator: DurationGenerator,
+    pub app_preferences: Vec<AppPreference>,
     pub concurrency_level: usize,
+    pub random_seed: u64,
     pub memory_name: String,
     pub force_fixed_memory: Option<u64>,
 }
@@ -110,8 +153,11 @@ pub struct AzureTraceConfig {
 impl Default for AzureTraceConfig {
     fn default() -> Self {
         Self {
-            invocations_limit: 0,
+            time_period: 60,
+            duration_generator: DurationGenerator::Piecewise,
+            app_preferences: Default::default(),
             concurrency_level: 1,
+            random_seed: 1,
             memory_name: "mem".to_string(),
             force_fixed_memory: None,
         }
@@ -120,8 +166,12 @@ impl Default for AzureTraceConfig {
 
 /// This function parses Azure trace and generates experiment.
 pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace {
-    let mut gen = Pcg64::seed_from_u64(1);
-    let mut trace = Vec::new();
+    for pref in config.app_preferences.iter() {
+        if let Err(e) = pref.validate() {
+            panic!("{}", e);
+        }
+    }
+    let mut gen = Pcg64::seed_from_u64(config.random_seed);
     let mut parts = BTreeSet::<String>::new();
     let mut mem = HashMap::<String, PathBuf>::new();
     let mut inv = HashMap::<String, PathBuf>::new();
@@ -152,44 +202,41 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
             panic!("error while reading trace dir: {}", e);
         }
     }
-    // values: (id, coldstart_latency, memory)
-    let mut app_data = HashMap::<String, (usize, f64, u64)>::new();
-    let mut fn_id = IndexMap::<String, usize>::new();
-    let dur_percent = vec![0., 0.01, 0.25, 0.50, 0.75, 0.99, 1.];
-    let mem_percent = vec![0.01, 0.05, 0.25, 0.50, 0.75, 0.95, 0.99, 1.];
-    let limit = config.invocations_limit / parts.len();
+    let mut bad_parts = Vec::new();
     for part in parts.iter() {
-        if !mem.contains_key(part) {
-            continue;
+        if !mem.contains_key(part) || !inv.contains_key(part) || !dur.contains_key(part) {
+            bad_parts.push(part.clone());
         }
-        let mut invocations_count = 0;
+    }
+    for part in bad_parts.iter() {
+        parts.remove(part);
+    }
+    let parts_needed = ((config.time_period + 1439) / 1440) as usize;
+    if parts.len() < parts_needed {
+        panic!("Trace is too short for specified time range.");
+    }
+    let tail_part = (config.time_period % 1440) as usize;
+    let mut app_mem = HashMap::<String, usize>::new();
+    for part in parts.iter().take(parts_needed) {
         let mut mem_file = ReaderBuilder::new()
             .from_path(mem.get(part).unwrap().as_path())
             .unwrap();
-        let mut inv_file = ReaderBuilder::new()
-            .from_path(inv.get(part).unwrap().as_path())
-            .unwrap();
-        let mut dur_file = ReaderBuilder::new()
-            .from_path(dur.get(part).unwrap().as_path())
-            .unwrap();
-        let mut app_funcs = HashMap::<String, HashSet<String>>::new();
-        let mut app_popularity = HashMap::<String, u64>::new();
-        let mut dur_dist = HashMap::<String, Vec<f64>>::new();
-        for dur_rec in dur_file.records() {
-            let record = dur_rec.unwrap();
+        for mem_rec in mem_file.records() {
+            let record = mem_rec.unwrap();
             let mut id = record[0].to_string();
             id.push('_');
             id.push_str(&record[1]);
-            id.push('_');
-            id.push_str(&record[2]);
-            let mut perc = Vec::with_capacity(dur_percent.len());
-            for i in 7..record.len() {
-                let val = f64::from_str(&record[i]).unwrap();
-                perc.push(val);
-            }
-            dur_dist.insert(id, perc);
+            let val = usize::from_str(&record[record.len() - 1]).unwrap();
+            let entry = app_mem.entry(id).or_default();
+            *entry = usize::max(*entry, val);
         }
-        let mut inv_cnt = HashMap::<String, Vec<usize>>::new();
+    }
+    let mut app_popularity = HashMap::<String, u64>::new();
+    for (part_id, part) in parts.iter().take(parts_needed).enumerate() {
+        let bound = if part_id + 1 == parts_needed { tail_part } else { 1440 };
+        let mut inv_file = ReaderBuilder::new()
+            .from_path(inv.get(part).unwrap().as_path())
+            .unwrap();
         for inv_rec in inv_file.records() {
             let record = inv_rec.unwrap();
             let mut id = record[0].to_string();
@@ -198,113 +245,161 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
             id.push('_');
             id.push_str(&record[2]);
             let app = app_id(&id);
-            if !app_funcs.contains_key(&app) {
-                app_funcs.insert(app.clone(), HashSet::new());
-                app_popularity.insert(app.clone(), 0);
+            if !app_mem.contains_key(&app) {
+                continue;
             }
-            app_funcs.get_mut(&app).unwrap().insert(id.clone());
-            let mut cnt = Vec::with_capacity(1440);
-            for i in 0..1440 {
-                cnt.push(usize::from_str(&record[4 + i]).unwrap());
+            let mut cnt = 0;
+            for i in 0..bound {
+                cnt += usize::from_str(&record[4 + i]).unwrap();
             }
-            *app_popularity.get_mut(&app).unwrap() += cnt.iter().sum::<usize>() as u64;
-            inv_cnt.insert(id, cnt);
+            if cnt > 0 {
+                *app_popularity.entry(app).or_default() += cnt as u64;
+            }
         }
-        let mut mem_dist = HashMap::<String, Vec<usize>>::new();
-        for mem_rec in mem_file.records() {
-            let record = mem_rec.unwrap();
+    }
+    let mut app_pop_vec = Vec::<(String, u64)>::from_iter(app_popularity.iter().map(|x| (x.0.to_string(), *x.1)));
+    app_pop_vec.sort_by_key(|x: &(String, u64)| -> (u64, String) { (x.1, x.0.clone()) });
+    app_pop_vec.reverse();
+    let all_apps = app_pop_vec.drain(..).map(|x| x.0).collect::<Vec<String>>();
+    let mut apps = IndexSet::new();
+    for pref in config.app_preferences.iter() {
+        let l = (pref.left * (all_apps.len() as f64)).floor() as usize;
+        let r = (pref.right * (all_apps.len() as f64)).floor() as usize;
+        if 1 + r - l < pref.count {
+            panic!(
+                "Not enough apps to satisfy preference ({}, {}, {})",
+                pref.count, pref.left, pref.right
+            );
+        }
+        apps.extend((&all_apps[l..=r]).choose_multiple(&mut gen, pref.count).cloned());
+    }
+    let mut fn_id = IndexMap::<String, usize>::new();
+    let dur_percent = vec![0., 0.01, 0.25, 0.50, 0.75, 0.99, 1.];
+    let mut invocations = Vec::<(usize, f64, f64)>::new();
+    for (part_id, part) in parts.iter().take(parts_needed).enumerate() {
+        let bound = if part_id + 1 == parts_needed { tail_part } else { 1440 };
+        let mut inv_file = ReaderBuilder::new()
+            .from_path(inv.get(part).unwrap().as_path())
+            .unwrap();
+        let mut dur_file = ReaderBuilder::new()
+            .from_path(dur.get(part).unwrap().as_path())
+            .unwrap();
+
+        let mut inv_map = HashMap::<String, (usize, usize)>::new();
+        for inv_rec in inv_file.records() {
+            let record = inv_rec.unwrap();
             let mut id = record[0].to_string();
             id.push('_');
             id.push_str(&record[1]);
-            let mut perc = Vec::with_capacity(mem_percent.len());
-            for i in 4..record.len() {
-                let val = usize::from_str(&record[i]).unwrap();
-                perc.push(val);
+            id.push('_');
+            id.push_str(&record[2]);
+            let app = app_id(&id);
+            if apps.contains(&app) {
+                let mut int_id = fn_id.len();
+                if let Some(idx) = fn_id.get(&id).copied() {
+                    int_id = idx;
+                } else {
+                    fn_id.insert(id.clone(), fn_id.len());
+                }
+                let begin = invocations.len();
+                let mut total = 0;
+                for t in 0..bound {
+                    let cnt = usize::from_str(&record[4 + t]).unwrap();
+                    total += cnt;
+                    for _ in 0..cnt {
+                        let second = gen.gen_range(0.0..1.0) * 60.0 + ((t * 60 + part_id * 1440 * 60) as f64);
+                        invocations.push((int_id, second, 0.));
+                    }
+                }
+                if total > 0 {
+                    inv_map.insert(id.clone(), (begin, total));
+                }
             }
-            mem_dist.insert(id, perc);
         }
-        let mut apps = Vec::<(String, u64)>::from_iter(app_popularity.iter().map(|x| (x.0.to_string(), *x.1)));
-        apps.sort_by_key(|x: &(String, u64)| -> (u64, String) { (x.1, x.0.clone()) });
-        apps.reverse();
-        //median popularity apps
-        let mid = apps.len() / 2 - 40;
-        let day = usize::from_str(&part[1..]).unwrap() - 1;
-        for (app, _) in apps.drain(mid..) {
-            if invocations_count == limit {
-                break;
-            }
-            if !mem_dist.contains_key(&app) {
-                continue;
-            }
-            let mem_vec = mem_dist.get(&app).unwrap();
-            let mem = gen_sample(&mut gen, &mem_percent, mem_vec);
-            if !app_data.contains_key(&app) {
-                app_data.insert(app.clone(), (app_data.len(), 0.1, mem as u64));
-            }
-            let mut funcs = Vec::new();
-            for f in app_funcs.get_mut(&app).unwrap().drain() {
-                funcs.push(f);
-            }
-            funcs.sort();
-            for func in funcs.drain(..) {
-                if invocations_count == limit {
-                    break;
-                }
-                let curr_id = fn_id.len();
-                fn_id.insert(func.clone(), curr_id);
-                if !dur_dist.contains_key(&func) {
-                    continue;
-                }
-                let dur_vec = dur_dist.get(&func).unwrap();
-                let inv_vec = inv_cnt.get(&func).unwrap();
-                for (i, inv) in inv_vec.iter().copied().enumerate() {
-                    for _ in 0..inv {
-                        let second = gen.gen_range(0.0..1.0) * 60.0 + ((i * 60 + day * 1440 * 64) as f64);
-                        let mut record = RequestData {
-                            id: curr_id,
-                            duration: f64::max(0.001, gen_sample(&mut gen, &dur_percent, dur_vec) * 0.001),
-                            time: second,
-                        };
-                        invocations_count += 1;
-                        record.duration = (record.duration * 1000000.).round() / 1000000.;
-                        record.time = (record.time * 1000000.).round() / 1000000.;
-                        trace.push(record);
-                        if invocations_count == limit {
-                            break;
+        match config.duration_generator {
+            DurationGenerator::Piecewise => {
+                for dur_rec in dur_file.records() {
+                    let record = dur_rec.unwrap();
+                    let mut id = record[0].to_string();
+                    id.push('_');
+                    id.push_str(&record[1]);
+                    id.push('_');
+                    id.push_str(&record[2]);
+                    if let Some((begin, len)) = inv_map.get(&id).copied() {
+                        let mut perc = Vec::with_capacity(dur_percent.len());
+                        for i in 7..record.len() {
+                            let val = f64::from_str(&record[i]).unwrap();
+                            perc.push(val);
+                        }
+                        for inv in &mut invocations[begin..begin + len] {
+                            inv.2 = f64::max(0.001, gen_sample(&mut gen, &dur_percent, &perc) * 0.001);
                         }
                     }
-                    if invocations_count == limit {
-                        break;
+                }
+            }
+            DurationGenerator::PrefittedLognormal => {
+                let dist = LogNormal::new(-0.38, 2.36).unwrap();
+                for inv in invocations.iter_mut() {
+                    inv.2 = f64::max(0.001, dist.sample(&mut gen));
+                }
+            }
+            DurationGenerator::Lognormal => {
+                for dur_rec in dur_file.records() {
+                    let record = dur_rec.unwrap();
+                    let mut id = record[0].to_string();
+                    id.push('_');
+                    id.push_str(&record[1]);
+                    id.push('_');
+                    id.push_str(&record[2]);
+                    if let Some((begin, len)) = inv_map.get(&id).copied() {
+                        let mean = f64::from_str(&record[3]).unwrap();
+                        let median = f64::from_str(&record[10]).unwrap();
+                        let squared_dev = 2. * (mean / median).ln();
+                        assert!(squared_dev >= 0.);
+                        let dist = LogNormal::new(median.ln(), squared_dev.sqrt()).unwrap();
+                        for inv in &mut invocations[begin..begin + len] {
+                            inv.2 = f64::max(0.001, dist.sample(&mut gen));
+                        }
                     }
                 }
             }
         }
     }
-    let mut apps: Vec<ApplicationRecord> = vec![Default::default(); app_data.len()];
-    let mut funcs: Vec<FunctionRecord> = vec![Default::default(); fn_id.len()];
-    for (_, data) in app_data.iter() {
-        apps[data.0] = ApplicationRecord {
-            mem: config.force_fixed_memory.unwrap_or(data.2),
-            cold_start: data.1,
+    let mut app_records: Vec<ApplicationRecord> = vec![Default::default(); apps.len()];
+    let mut func_records: Vec<FunctionRecord> = vec![Default::default(); fn_id.len()];
+    let mut app_indices = HashMap::<String, usize>::new();
+    for (i, app) in apps.iter().enumerate() {
+        app_records[i] = ApplicationRecord {
+            mem: config.force_fixed_memory.unwrap_or_else(|| app_mem.get(app).copied().unwrap() as u64),
+            cold_start: 0.1,
         };
+        app_indices.insert(app.clone(), i);
     }
     for (name, id) in fn_id.iter() {
         let app = app_id(name);
-        funcs[*id] = FunctionRecord {
-            app_id: app_data.get(&app).unwrap().0,
+        func_records[*id] = FunctionRecord {
+            app_id: *app_indices.get(&app).unwrap(),
         };
     }
-    trace.sort_by(|x: &RequestData, y: &RequestData| x.time.partial_cmp(&y.time).unwrap());
+    invocations.sort_by(|x: &(usize, f64, f64), y: &(usize, f64, f64)| x.1.total_cmp(&y.1));
     let mut time_range = 0.0;
-    for req in trace.iter() {
-        time_range = f64::max(time_range, req.time + req.duration);
+    for req in invocations.iter() {
+        time_range = f64::max(time_range, req.1 + req.2);
     }
+    let trace = invocations
+        .drain(..)
+        .map(|x| RequestData {
+            id: x.0,
+            duration: x.2,
+            time: x.1,
+        })
+        .collect::<Vec<_>>();
     AzureTrace {
         concurrency_level: config.concurrency_level,
         memory_name: config.memory_name,
         sim_end: Some(time_range),
         trace_records: trace,
-        function_records: funcs,
-        app_records: apps,
+        function_records: func_records,
+        app_records,
     }
 }

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -352,8 +352,8 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
                     id.push('_');
                     id.push_str(&record[2]);
                     if let Some((begin, len)) = inv_map.get(&id).copied() {
-                        let mean = f64::from_str(&record[3]).unwrap();
-                        let median = f64::from_str(&record[10]).unwrap();
+                        let mean = f64::from_str(&record[3]).unwrap() * 0.001;
+                        let median = f64::from_str(&record[10]).unwrap() * 0.001;
                         let squared_dev = 2. * (mean / median).ln();
                         assert!(squared_dev >= 0.);
                         let dist = LogNormal::new(median.ln(), squared_dev.sqrt()).unwrap();

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -173,8 +173,8 @@ pub struct AzureTraceConfig {
     pub force_fixed_memory: Option<u64>,
     /// Cold start latency, currently it's the same for all apps.
     pub cold_start_latency: f64,
-    /// If `rps` is not None, trace generator attempts to scale trace to the given number of requests
-    /// per second by either removing random requests or duplicating random requests (yes, that doesn't sound very solid).
+    /// If `rps` is not None, trace generator attempts to scale trace to the given number of requests per second
+    /// by either removing random requests or duplicating random requests (yes, that doesn't sound very solid).
     pub rps: Option<f64>,
 }
 

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -103,7 +103,7 @@ fn app_id(id: &str) -> String {
     id0
 }
 
-/// Experiment generator will choose `count` random apps with popularity in range [floor(`left` * n_apps), floor(`right` * n_apps)] (less = more popular).
+/// Experiment generator will choose `count` random apps with popularity in range [floor(`left` * n_apps), floor(`right` * n_apps)] (apps are sorted by popularity in decreasing order).
 pub struct AppPreference {
     pub count: usize,
     pub left: f64,
@@ -243,7 +243,10 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
     if parts.len() < parts_needed {
         panic!("Trace is too short for specified time range.");
     }
-    let tail_part = (config.time_period % 1440) as usize;
+    let mut tail_part = (config.time_period % 1440) as usize;
+    if tail_part == 0 {
+        tail_part = 1440;
+    }
     let mut app_mem = HashMap::<String, usize>::new();
     for part in parts.iter().take(parts_needed) {
         let mut mem_file = ReaderBuilder::new()

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -167,6 +167,8 @@ pub struct AzureTraceConfig {
     pub memory_name: String,
     /// This option forces trace generator to use given amount of memory for all apps.
     pub force_fixed_memory: Option<u64>,
+    /// Cold start latency, currently it's the same for all apps.
+    pub cold_start_latency: f64,
     /// If `rps` is not None, trace generator attempts to scale trace to the given number of requests
     /// per second by either removing random requests or duplicating random requests (yes, that
     /// doesn't sound very solid).
@@ -184,6 +186,7 @@ impl Default for AzureTraceConfig {
             random_seed: 1,
             memory_name: "mem".to_string(),
             force_fixed_memory: None,
+            cold_start_latency: 1.,
             rps: None,
         }
     }
@@ -463,7 +466,7 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
             mem: config
                 .force_fixed_memory
                 .unwrap_or_else(|| app_mem.get(app).copied().unwrap() as u64),
-            cold_start: 0.1,
+            cold_start: config.cold_start_latency,
         };
         app_indices.insert(app.clone(), i);
     }

--- a/crates/dslab-faas/src/extra/azure_trace.rs
+++ b/crates/dslab-faas/src/extra/azure_trace.rs
@@ -370,7 +370,9 @@ pub fn process_azure_trace(path: &Path, config: AzureTraceConfig) -> AzureTrace 
     let mut app_indices = HashMap::<String, usize>::new();
     for (i, app) in apps.iter().enumerate() {
         app_records[i] = ApplicationRecord {
-            mem: config.force_fixed_memory.unwrap_or_else(|| app_mem.get(app).copied().unwrap() as u64),
+            mem: config
+                .force_fixed_memory
+                .unwrap_or_else(|| app_mem.get(app).copied().unwrap() as u64),
             cold_start: 0.1,
         };
         app_indices.insert(app.clone(), i);

--- a/crates/dslab-faas/src/host.rs
+++ b/crates/dslab-faas/src/host.rs
@@ -8,7 +8,7 @@ use dslab_core::handler::EventHandler;
 
 use crate::coldstart::ColdStartPolicy;
 use crate::container::{ContainerManager, ContainerStatus};
-use crate::cpu::CPU;
+use crate::cpu::{CPUPolicy, CPU};
 use crate::event::{ContainerEndEvent, ContainerStartEvent, IdleDeployEvent, InvocationEndEvent};
 use crate::function::{Application, FunctionRegistry};
 use crate::invocation::{InvocationRegistry, InvocationStatus};
@@ -35,7 +35,7 @@ impl Host {
     pub fn new(
         id: usize,
         cores: u32,
-        disable_contention: bool,
+        cpu_policy: Box<dyn CPUPolicy>,
         resources: ResourceProvider,
         invoker: Box<dyn Invoker>,
         function_registry: Rc<RefCell<FunctionRegistry>>,
@@ -50,7 +50,7 @@ impl Host {
             id,
             invoker,
             container_manager: ContainerManager::new(resources, ctx.clone()),
-            cpu: CPU::new(cores, disable_contention, ctx.clone()),
+            cpu: CPU::new(cores, cpu_policy, ctx.clone()),
             function_registry,
             invocation_registry,
             coldstart,

--- a/crates/dslab-faas/src/host.rs
+++ b/crates/dslab-faas/src/host.rs
@@ -107,7 +107,7 @@ impl Host {
             time,
         );
         let mut stats = self.stats.borrow_mut();
-        stats.on_new_invocation(invocation.func_id);
+        stats.on_new_invocation(invocation.app_id, invocation.func_id);
         match status {
             InvokerDecision::Warm(container_id) => {
                 drop(stats);
@@ -117,7 +117,7 @@ impl Host {
             InvokerDecision::Cold((container_id, delay)) => {
                 invocation.status = InvocationStatus::WaitingForContainer;
                 invocation.container_id = Some(container_id);
-                stats.on_cold_start(invocation.func_id, delay);
+                stats.on_cold_start(invocation.app_id, invocation.func_id, delay);
                 drop(stats);
                 self.container_manager.reserve_container(container_id, id);
             }

--- a/crates/dslab-faas/src/host.rs
+++ b/crates/dslab-faas/src/host.rs
@@ -138,7 +138,7 @@ impl Host {
             if container.status == ContainerStatus::Idle {
                 let delta = time - container.last_change;
                 stats.update_wasted_resources(delta, &container.resources);
-                container.status = ContainerStatus::Deploying;
+                container.last_change = time;
             }
         }
     }

--- a/crates/dslab-faas/src/host.rs
+++ b/crates/dslab-faas/src/host.rs
@@ -8,7 +8,7 @@ use dslab_core::handler::EventHandler;
 
 use crate::coldstart::ColdStartPolicy;
 use crate::container::{ContainerManager, ContainerStatus};
-use crate::cpu::{CPUPolicy, CPU};
+use crate::cpu::{CpuPolicy, Cpu};
 use crate::event::{ContainerEndEvent, ContainerStartEvent, IdleDeployEvent, InvocationEndEvent};
 use crate::function::{Application, FunctionRegistry};
 use crate::invocation::{InvocationRegistry, InvocationStatus};
@@ -21,7 +21,7 @@ pub struct Host {
     id: usize,
     invoker: Box<dyn Invoker>,
     container_manager: ContainerManager,
-    cpu: CPU,
+    cpu: Cpu,
     function_registry: Rc<RefCell<FunctionRegistry>>,
     invocation_registry: Rc<RefCell<InvocationRegistry>>,
     coldstart: Rc<RefCell<dyn ColdStartPolicy>>,
@@ -35,7 +35,7 @@ impl Host {
     pub fn new(
         id: usize,
         cores: u32,
-        cpu_policy: Box<dyn CPUPolicy>,
+        cpu_policy: Box<dyn CpuPolicy>,
         resources: ResourceProvider,
         invoker: Box<dyn Invoker>,
         function_registry: Rc<RefCell<FunctionRegistry>>,
@@ -50,7 +50,7 @@ impl Host {
             id,
             invoker,
             container_manager: ContainerManager::new(resources, ctx.clone()),
-            cpu: CPU::new(cores, cpu_policy, ctx.clone()),
+            cpu: Cpu::new(cores, cpu_policy, ctx.clone()),
             function_registry,
             invocation_registry,
             coldstart,

--- a/crates/dslab-faas/src/host.rs
+++ b/crates/dslab-faas/src/host.rs
@@ -8,7 +8,7 @@ use dslab_core::handler::EventHandler;
 
 use crate::coldstart::ColdStartPolicy;
 use crate::container::{ContainerManager, ContainerStatus};
-use crate::cpu::{CpuPolicy, Cpu};
+use crate::cpu::{Cpu, CpuPolicy};
 use crate::event::{ContainerEndEvent, ContainerStartEvent, IdleDeployEvent, InvocationEndEvent};
 use crate::function::{Application, FunctionRegistry};
 use crate::invocation::{InvocationRegistry, InvocationStatus};

--- a/crates/dslab-faas/src/invocation.rs
+++ b/crates/dslab-faas/src/invocation.rs
@@ -17,6 +17,7 @@ pub enum InvocationStatus {
 #[derive(Copy, Clone)]
 pub struct Invocation {
     pub id: usize,
+    pub app_id: usize,
     pub func_id: usize,
     pub duration: f64,
     pub arrival_time: f64,
@@ -47,10 +48,11 @@ pub struct InvocationRegistry {
 }
 
 impl InvocationRegistry {
-    pub fn add_invocation(&mut self, func_id: usize, duration: f64, arrival_time: f64) -> usize {
+    pub fn add_invocation(&mut self, app_id: usize, func_id: usize, duration: f64, arrival_time: f64) -> usize {
         let id = self.invocations.len();
         let invocation = Invocation {
             id,
+            app_id,
             func_id,
             duration,
             arrival_time,

--- a/crates/dslab-faas/src/invoker.rs
+++ b/crates/dslab-faas/src/invoker.rs
@@ -144,6 +144,7 @@ impl Invoker for NaiveInvoker {
                         let delta = time - container.last_change;
                         stats.update_wasted_resources(delta, &container.resources);
                     }
+                    stats.on_cold_start(item.app_id, item.func_id, time - item.time);
                     container.last_change = time;
                     container.status = ContainerStatus::Running;
                     container.start_invocation(item.invocation_id);
@@ -152,7 +153,7 @@ impl Invoker for NaiveInvoker {
                 InvokerDecision::Cold((id, delay)) => {
                     stats.update_queueing_time(item.app_id, item.func_id, time - item.time);
                     cm.reserve_container(id, item.invocation_id);
-                    stats.on_cold_start(item.app_id, item.func_id, delay);
+                    stats.on_cold_start(item.app_id, item.func_id, time - item.time + delay);
                     dequeued.push(DequeuedInvocation::new(item.invocation_id, id, Some(delay)));
                 }
                 InvokerDecision::Rejected => {
@@ -230,6 +231,7 @@ impl Invoker for FIFOInvoker {
                         let delta = time - container.last_change;
                         stats.update_wasted_resources(delta, &container.resources);
                     }
+                    stats.on_cold_start(item.app_id, item.func_id, time - item.time);
                     container.last_change = time;
                     container.status = ContainerStatus::Running;
                     container.start_invocation(item.invocation_id);
@@ -239,7 +241,7 @@ impl Invoker for FIFOInvoker {
                 InvokerDecision::Cold((id, delay)) => {
                     stats.update_queueing_time(item.app_id, item.func_id, time - item.time);
                     cm.reserve_container(id, item.invocation_id);
-                    stats.on_cold_start(item.app_id, item.func_id, delay);
+                    stats.on_cold_start(item.app_id, item.func_id, time - item.time + delay);
                     dequeued.push(DequeuedInvocation::new(item.invocation_id, id, Some(delay)));
                     self.queue.pop_front();
                 }

--- a/crates/dslab-faas/src/parallel.rs
+++ b/crates/dslab-faas/src/parallel.rs
@@ -47,7 +47,7 @@ impl Default for ParallelConfig {
     fn default() -> Self {
         Self {
             coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(0.0, 0.0)),
-            cpu_policy: Box::new(ContendedCPUPolicy::default()),
+            cpu_policy: Box::<ContendedCPUPolicy>::default(),
             idle_deployer: Box::new(BasicDeployer {}),
             scheduler: Box::new(BasicScheduler {}),
             hosts: Vec::new(),

--- a/crates/dslab-faas/src/parallel.rs
+++ b/crates/dslab-faas/src/parallel.rs
@@ -11,7 +11,7 @@ use dslab_core::simulation::Simulation;
 
 use crate::coldstart::{ColdStartPolicy, FixedTimeColdStartPolicy};
 use crate::config::{Config, ConfigParamResolvers, RawConfig};
-use crate::cpu::{CpuPolicy, ContendedCpuPolicy};
+use crate::cpu::{ContendedCpuPolicy, CpuPolicy};
 use crate::deployer::{BasicDeployer, IdleDeployer};
 use crate::invoker::{FIFOInvoker, Invoker};
 use crate::scheduler::{BasicScheduler, Scheduler};

--- a/crates/dslab-faas/src/parallel.rs
+++ b/crates/dslab-faas/src/parallel.rs
@@ -12,7 +12,7 @@ use dslab_core::simulation::Simulation;
 use crate::coldstart::{ColdStartPolicy, FixedTimeColdStartPolicy};
 use crate::config::{Config, ConfigParamResolvers, RawConfig};
 use crate::deployer::{BasicDeployer, IdleDeployer};
-use crate::invoker::{BasicInvoker, Invoker};
+use crate::invoker::{FIFOInvoker, Invoker};
 use crate::scheduler::{BasicScheduler, Scheduler};
 use crate::simulation::ServerlessSimulation;
 use crate::stats::Stats;
@@ -27,7 +27,7 @@ pub struct ParallelHostConfig {
 impl Default for ParallelHostConfig {
     fn default() -> Self {
         Self {
-            invoker: Box::new(BasicInvoker::new()),
+            invoker: Box::new(FIFOInvoker::new()),
             resources: Vec::new(),
             cores: 1,
         }

--- a/crates/dslab-faas/src/parallel.rs
+++ b/crates/dslab-faas/src/parallel.rs
@@ -11,7 +11,7 @@ use dslab_core::simulation::Simulation;
 
 use crate::coldstart::{ColdStartPolicy, FixedTimeColdStartPolicy};
 use crate::config::{Config, ConfigParamResolvers, RawConfig};
-use crate::cpu::{CPUPolicy, ContendedCPUPolicy};
+use crate::cpu::{CpuPolicy, ContendedCpuPolicy};
 use crate::deployer::{BasicDeployer, IdleDeployer};
 use crate::invoker::{FIFOInvoker, Invoker};
 use crate::scheduler::{BasicScheduler, Scheduler};
@@ -37,7 +37,7 @@ impl Default for ParallelHostConfig {
 
 pub struct ParallelConfig {
     pub coldstart_policy: Box<dyn ColdStartPolicy + Send>,
-    pub cpu_policy: Box<dyn CPUPolicy + Send>,
+    pub cpu_policy: Box<dyn CpuPolicy + Send>,
     pub idle_deployer: Box<dyn IdleDeployer + Send>,
     pub scheduler: Box<dyn Scheduler + Send>,
     pub hosts: Vec<ParallelHostConfig>,
@@ -47,7 +47,7 @@ impl Default for ParallelConfig {
     fn default() -> Self {
         Self {
             coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(0.0, 0.0)),
-            cpu_policy: Box::<ContendedCPUPolicy>::default(),
+            cpu_policy: Box::<ContendedCpuPolicy>::default(),
             idle_deployer: Box::new(BasicDeployer {}),
             scheduler: Box::new(BasicScheduler {}),
             hosts: Vec::new(),
@@ -144,7 +144,7 @@ pub fn parallel_simulation_raw_n_workers(
     }
     let coldstart_policy_resolver1: Arc<dyn Fn(&str) -> Box<dyn ColdStartPolicy> + Send + Sync> =
         Arc::from(resolvers.coldstart_policy_resolver);
-    let cpu_policy_resolver1: Arc<dyn Fn(&str) -> Box<dyn CPUPolicy> + Send + Sync> =
+    let cpu_policy_resolver1: Arc<dyn Fn(&str) -> Box<dyn CpuPolicy> + Send + Sync> =
         Arc::from(resolvers.cpu_policy_resolver);
     let idle_deployer_resolver1: Arc<dyn Fn(&str) -> Box<dyn IdleDeployer> + Send + Sync> =
         Arc::from(resolvers.idle_deployer_resolver);

--- a/crates/dslab-faas/src/parallel.rs
+++ b/crates/dslab-faas/src/parallel.rs
@@ -11,6 +11,7 @@ use dslab_core::simulation::Simulation;
 
 use crate::coldstart::{ColdStartPolicy, FixedTimeColdStartPolicy};
 use crate::config::{Config, ConfigParamResolvers, RawConfig};
+use crate::cpu::{CPUPolicy, ContendedCPUPolicy};
 use crate::deployer::{BasicDeployer, IdleDeployer};
 use crate::invoker::{FIFOInvoker, Invoker};
 use crate::scheduler::{BasicScheduler, Scheduler};
@@ -36,7 +37,7 @@ impl Default for ParallelHostConfig {
 
 pub struct ParallelConfig {
     pub coldstart_policy: Box<dyn ColdStartPolicy + Send>,
-    pub disable_contention: bool,
+    pub cpu_policy: Box<dyn CPUPolicy + Send>,
     pub idle_deployer: Box<dyn IdleDeployer + Send>,
     pub scheduler: Box<dyn Scheduler + Send>,
     pub hosts: Vec<ParallelHostConfig>,
@@ -46,7 +47,7 @@ impl Default for ParallelConfig {
     fn default() -> Self {
         Self {
             coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(0.0, 0.0)),
-            disable_contention: false,
+            cpu_policy: Box::new(ContendedCPUPolicy::default()),
             idle_deployer: Box::new(BasicDeployer {}),
             scheduler: Box::new(BasicScheduler {}),
             hosts: Vec::new(),
@@ -143,6 +144,8 @@ pub fn parallel_simulation_raw_n_workers(
     }
     let coldstart_policy_resolver1: Arc<dyn Fn(&str) -> Box<dyn ColdStartPolicy> + Send + Sync> =
         Arc::from(resolvers.coldstart_policy_resolver);
+    let cpu_policy_resolver1: Arc<dyn Fn(&str) -> Box<dyn CPUPolicy> + Send + Sync> =
+        Arc::from(resolvers.cpu_policy_resolver);
     let idle_deployer_resolver1: Arc<dyn Fn(&str) -> Box<dyn IdleDeployer> + Send + Sync> =
         Arc::from(resolvers.idle_deployer_resolver);
     let scheduler_resolver1: Arc<dyn Fn(&str) -> Box<dyn Scheduler> + Send + Sync> =
@@ -154,6 +157,7 @@ pub fn parallel_simulation_raw_n_workers(
     for (id, raw_config, trace, seed) in izip!(0..len, configs.drain(..), traces_arc.drain(..), seeds.drain(..)) {
         let tx = tx.clone();
         let coldstart_policy_resolver = coldstart_policy_resolver1.clone();
+        let cpu_policy_resolver = cpu_policy_resolver1.clone();
         let idle_deployer_resolver = idle_deployer_resolver1.clone();
         let scheduler_resolver = scheduler_resolver1.clone();
         let invoker_resolver = invoker_resolver1.clone();
@@ -161,6 +165,7 @@ pub fn parallel_simulation_raw_n_workers(
             let config = Config::from_raw_split_resolvers(
                 raw_config,
                 coldstart_policy_resolver.as_ref(),
+                cpu_policy_resolver.as_ref(),
                 idle_deployer_resolver.as_ref(),
                 scheduler_resolver.as_ref(),
                 invoker_resolver.as_ref(),

--- a/crates/dslab-faas/src/scheduler.rs
+++ b/crates/dslab-faas/src/scheduler.rs
@@ -225,13 +225,18 @@ impl Scheduler for LeastLoadedScheduler {
                     host.borrow().get_cpu_load()
                 },
             );
-            if load < best_load {
+            if load.0 > best_load.0 || (load.1 + 1e-9 < best_load.1) {
                 best_load = load;
                 best = i;
                 if self.prefer_warm {
                     warm = host.borrow().can_invoke(app, false);
                 }
-            } else if load == best_load && self.prefer_warm && !warm && host.borrow().can_invoke(app, false) {
+            } else if load.0 == best_load.0
+                && (load.1 - best_load.1).abs() < 1e-9
+                && self.prefer_warm
+                && !warm
+                && host.borrow().can_invoke(app, false)
+            {
                 best = i;
                 warm = true;
             }

--- a/crates/dslab-faas/src/simulation.rs
+++ b/crates/dslab-faas/src/simulation.rs
@@ -111,7 +111,7 @@ impl ServerlessSimulation {
         let host = Rc::new(RefCell::new(Host::new(
             id,
             cores,
-            self.cpu_policy.clean_copy(),
+            self.cpu_policy.init(cores),
             resources,
             real_invoker,
             self.function_registry.clone(),

--- a/crates/dslab-faas/src/simulation.rs
+++ b/crates/dslab-faas/src/simulation.rs
@@ -9,7 +9,7 @@ use dslab_core::simulation::Simulation;
 use crate::coldstart::ColdStartPolicy;
 use crate::config::Config;
 use crate::controller::Controller;
-use crate::cpu::CPUPolicy;
+use crate::cpu::CpuPolicy;
 use crate::event::{InvocationStartEvent, SimulationEndEvent};
 use crate::function::{Application, Function, FunctionRegistry};
 use crate::host::Host;
@@ -26,7 +26,7 @@ pub struct ServerlessSimulation {
     coldstart: Rc<RefCell<dyn ColdStartPolicy>>,
     controller: Rc<RefCell<Controller>>,
     controller_id: HandlerId,
-    cpu_policy: Box<dyn CPUPolicy>,
+    cpu_policy: Box<dyn CpuPolicy>,
     function_registry: Rc<RefCell<FunctionRegistry>>,
     host_ctr: Counter,
     invocation_registry: Rc<RefCell<InvocationRegistry>>,

--- a/crates/dslab-faas/src/simulation.rs
+++ b/crates/dslab-faas/src/simulation.rs
@@ -12,7 +12,7 @@ use crate::event::{InvocationStartEvent, SimulationEndEvent};
 use crate::function::{Application, Function, FunctionRegistry};
 use crate::host::Host;
 use crate::invocation::{Invocation, InvocationRegistry};
-use crate::invoker::{BasicInvoker, Invoker};
+use crate::invoker::{FIFOInvoker, Invoker};
 use crate::resource::{Resource, ResourceConsumer, ResourceNameResolver, ResourceProvider, ResourceRequirement};
 use crate::stats::{GlobalStats, InvocationStats, Stats};
 use crate::trace::{RequestData, Trace};
@@ -104,7 +104,7 @@ impl ServerlessSimulation {
 
     pub fn add_host(&mut self, invoker: Option<Box<dyn Invoker>>, resources: ResourceProvider, cores: u32) {
         let id = self.host_ctr.increment();
-        let real_invoker = invoker.unwrap_or_else(|| Box::new(BasicInvoker::new()));
+        let real_invoker = invoker.unwrap_or_else(|| Box::new(FIFOInvoker::new()));
         let ctx = self.sim.create_context(format!("host_{}", id));
         let host = Rc::new(RefCell::new(Host::new(
             id,

--- a/crates/dslab-faas/src/stats.rs
+++ b/crates/dslab-faas/src/stats.rs
@@ -204,28 +204,33 @@ impl GlobalStats {
 
 #[derive(Clone, Default)]
 pub struct Stats {
+    pub app_stats: DefaultVecMap<InvocationStats>,
     pub func_stats: DefaultVecMap<InvocationStats>,
     pub global_stats: GlobalStats,
 }
 
 impl Stats {
-    pub fn on_cold_start(&mut self, func_id: usize, delay: f64) {
+    pub fn on_cold_start(&mut self, app_id: usize, func_id: usize, delay: f64) {
         self.global_stats.on_cold_start(delay);
+        self.app_stats.get_mut(app_id).on_cold_start(delay);
         self.func_stats.get_mut(func_id).on_cold_start(delay);
     }
 
-    pub fn on_new_invocation(&mut self, func_id: usize) {
+    pub fn on_new_invocation(&mut self, app_id: usize, func_id: usize) {
         self.global_stats.on_new_invocation();
+        self.app_stats.get_mut(app_id).on_new_invocation();
         self.func_stats.get_mut(func_id).on_new_invocation();
     }
 
     pub fn update_invocation_stats(&mut self, invocation: &Invocation) {
         self.global_stats.update_invocation_stats(invocation);
+        self.app_stats.get_mut(invocation.app_id).update(invocation);
         self.func_stats.get_mut(invocation.func_id).update(invocation);
     }
 
-    pub fn update_queueing_time(&mut self, func_id: usize, queueing_time: f64) {
+    pub fn update_queueing_time(&mut self, app_id: usize, func_id: usize, queueing_time: f64) {
         self.global_stats.update_queueing_time(queueing_time);
+        self.app_stats.get_mut(app_id).update_queueing_time(queueing_time);
         self.func_stats.get_mut(func_id).update_queueing_time(queueing_time);
     }
 

--- a/crates/dslab-faas/src/stats.rs
+++ b/crates/dslab-faas/src/stats.rs
@@ -1,4 +1,6 @@
 use order_stat::kth_by;
+use serde::ser::{SerializeSeq, Serializer};
+use serde::Serialize;
 
 use crate::invocation::Invocation;
 use crate::resource::ResourceConsumer;
@@ -109,7 +111,20 @@ impl SampleMetric {
     }
 }
 
-#[derive(Clone, Default)]
+impl Serialize for SampleMetric {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.data.len()))?;
+        for x in self.data.iter() {
+            seq.serialize_element(x)?;
+        }
+        seq.end()
+    }
+}
+
+#[derive(Clone, Default, Serialize)]
 pub struct InvocationStats {
     pub invocations: u64,
     pub cold_starts: u64,
@@ -149,7 +164,7 @@ impl InvocationStats {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize)]
 pub struct GlobalStats {
     pub invocation_stats: InvocationStats,
     pub wasted_resource_time: DefaultVecMap<SampleMetric>,
@@ -202,7 +217,7 @@ impl GlobalStats {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize)]
 pub struct Stats {
     pub app_stats: DefaultVecMap<InvocationStats>,
     pub func_stats: DefaultVecMap<InvocationStats>,

--- a/crates/dslab-faas/src/util.rs
+++ b/crates/dslab-faas/src/util.rs
@@ -57,6 +57,33 @@ impl<T> VecMap<T> {
             None
         }
     }
+
+    pub fn iter(&self) -> VecMapIterator<'_, T> {
+        VecMapIterator::new(self.data.iter().enumerate())
+    }
+}
+
+pub struct VecMapIterator<'a, T> {
+    inner: std::iter::Enumerate<std::slice::Iter<'a, Option<T>>>,
+}
+
+impl<'a, T> VecMapIterator<'a, T> {
+    pub fn new(inner: std::iter::Enumerate<std::slice::Iter<'a, Option<T>>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, T> Iterator for VecMapIterator<'a, T> {
+    type Item = (usize, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((id, x)) = self.inner.next() {
+            if let Some(y) = x.as_ref() {
+                return Some((id, y));
+            }
+        }
+        None
+    }
 }
 
 impl<T> Index<usize> for VecMap<T> {
@@ -106,6 +133,10 @@ where
     pub fn get_mut(&mut self, id: usize) -> &mut T {
         self.extend(id);
         &mut self.data[id]
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.data.iter()
     }
 }
 

--- a/crates/dslab-faas/src/util.rs
+++ b/crates/dslab-faas/src/util.rs
@@ -3,6 +3,8 @@ use std::ops::{Index, IndexMut};
 
 use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxHasher;
+use serde::ser::{SerializeSeq, Serializer};
+use serde::Serialize;
 
 #[derive(Default)]
 pub struct Counter {
@@ -157,6 +159,22 @@ where
 {
     fn index_mut(&mut self, id: usize) -> &mut Self::Output {
         &mut self.data[id]
+    }
+}
+
+impl<T> Serialize for DefaultVecMap<T>
+where
+    T: Default + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.data.len()))?;
+        for x in self.data.iter() {
+            seq.serialize_element(x)?;
+        }
+        seq.end()
     }
 }
 

--- a/crates/dslab-faas/src/util.rs
+++ b/crates/dslab-faas/src/util.rs
@@ -77,7 +77,7 @@ impl<'a, T> Iterator for VecMapIterator<'a, T> {
     type Item = (usize, &'a T);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((id, x)) = self.inner.next() {
+        for (id, x) in self.inner.by_ref() {
             if let Some(y) = x.as_ref() {
                 return Some((id, y));
             }

--- a/crates/dslab-faas/tests/test_invocation_lifecycle.rs
+++ b/crates/dslab-faas/tests/test_invocation_lifecycle.rs
@@ -3,6 +3,7 @@ use std::boxed::Box;
 use dslab_core::simulation::Simulation;
 use dslab_faas::coldstart::FixedTimeColdStartPolicy;
 use dslab_faas::config::Config;
+use dslab_faas::cpu::IgnoredCPUPolicy;
 use dslab_faas::function::Application;
 use dslab_faas::invocation::InvocationStatus;
 use dslab_faas::resource::{ResourceConsumer, ResourceProvider};
@@ -12,7 +13,7 @@ use dslab_faas::simulation::ServerlessSimulation;
 fn test_invocation_lifecycle() {
     let config = Config {
         coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(1.0, 0.0)),
-        disable_contention: true,
+        cpu_policy: Box::new(IgnoredCPUPolicy::default()),
         ..Default::default()
     };
     let mut sim = ServerlessSimulation::new(Simulation::new(1), config);

--- a/crates/dslab-faas/tests/test_invocation_lifecycle.rs
+++ b/crates/dslab-faas/tests/test_invocation_lifecycle.rs
@@ -3,7 +3,7 @@ use std::boxed::Box;
 use dslab_core::simulation::Simulation;
 use dslab_faas::coldstart::FixedTimeColdStartPolicy;
 use dslab_faas::config::Config;
-use dslab_faas::cpu::IgnoredCPUPolicy;
+use dslab_faas::cpu::IgnoredCpuPolicy;
 use dslab_faas::function::Application;
 use dslab_faas::invocation::InvocationStatus;
 use dslab_faas::resource::{ResourceConsumer, ResourceProvider};
@@ -13,7 +13,7 @@ use dslab_faas::simulation::ServerlessSimulation;
 fn test_invocation_lifecycle() {
     let config = Config {
         coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(1.0, 0.0)),
-        cpu_policy: Box::new(IgnoredCPUPolicy::default()),
+        cpu_policy: Box::new(IgnoredCpuPolicy::default()),
         ..Default::default()
     };
     let mut sim = ServerlessSimulation::new(Simulation::new(1), config);

--- a/crates/dslab-faas/tests/test_simulation.rs
+++ b/crates/dslab-faas/tests/test_simulation.rs
@@ -68,8 +68,9 @@ fn test_simulation_with_invoker_queueing() {
     let stats = sim.stats();
     let inv_stats = stats.global_stats.invocation_stats;
     assert_eq!(inv_stats.invocations, 3);
-    assert_eq!(inv_stats.cold_starts, 2);
-    assert_float_eq(inv_stats.cold_start_latency.min().unwrap(), 1.0, 1e-9);
+    assert_eq!(inv_stats.cold_starts, 3);
+    assert_eq!(inv_stats.queueing_time.len(), 1);
+    assert_float_eq(inv_stats.cold_start_latency.min().unwrap(), 0.1, 1e-9);
     assert_float_eq(inv_stats.cold_start_latency.max().unwrap(), 1.0, 1e-9);
     assert_float_eq(inv_stats.abs_exec_slowdown.mean(), 2.0 / 3.0, 1e-9);
     assert_float_eq(inv_stats.rel_exec_slowdown.mean(), 2.0 / 3.0, 1e-9);

--- a/crates/dslab-faas/tests/test_stats.rs
+++ b/crates/dslab-faas/tests/test_stats.rs
@@ -9,6 +9,7 @@ fn test_invocation_stats() {
     let mut stats: InvocationStats = Default::default();
     let inv1 = Invocation {
         id: 0,
+        app_id: 0,
         func_id: 0,
         duration: 1.0,
         arrival_time: 0.0,
@@ -20,6 +21,7 @@ fn test_invocation_stats() {
     };
     let inv2 = Invocation {
         id: 1,
+        app_id: 0,
         func_id: 0,
         duration: 1.2,
         arrival_time: 0.0,
@@ -31,6 +33,7 @@ fn test_invocation_stats() {
     };
     let inv3 = Invocation {
         id: 2,
+        app_id: 0,
         func_id: 0,
         duration: 1.0,
         arrival_time: 2.0,

--- a/examples/faas-opendc-benchmark/src/main.rs
+++ b/examples/faas-opendc-benchmark/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use dslab_core::simulation::Simulation;
 use dslab_faas::coldstart::FixedTimeColdStartPolicy;
 use dslab_faas::config::Config;
+use dslab_faas::cpu::IgnoredCPUPolicy;
 use dslab_faas::extra::opendc_trace::{process_opendc_trace, OpenDCTraceConfig};
 use dslab_faas::resource::ResourceProvider;
 use dslab_faas::simulation::ServerlessSimulation;
@@ -25,7 +26,7 @@ fn main() {
     };
     let trace = process_opendc_trace(Path::new(&args.trace), trace_config);
     let config = Config {
-        disable_contention: true,
+        cpu_policy: Box::new(IgnoredCPUPolicy::default()),
         coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(120.0 * 60.0, 0.0)),
         ..Default::default()
     };

--- a/examples/faas-opendc-benchmark/src/main.rs
+++ b/examples/faas-opendc-benchmark/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     };
     let trace = process_opendc_trace(Path::new(&args.trace), trace_config);
     let config = Config {
-        cpu_policy: Box::new(IgnoredCPUPolicy::default()),
+        cpu_policy: Box::<IgnoredCPUPolicy>::default(),
         coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(120.0 * 60.0, 0.0)),
         ..Default::default()
     };

--- a/examples/faas-opendc-benchmark/src/main.rs
+++ b/examples/faas-opendc-benchmark/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use dslab_core::simulation::Simulation;
 use dslab_faas::coldstart::FixedTimeColdStartPolicy;
 use dslab_faas::config::Config;
-use dslab_faas::cpu::IgnoredCPUPolicy;
+use dslab_faas::cpu::IgnoredCpuPolicy;
 use dslab_faas::extra::opendc_trace::{process_opendc_trace, OpenDCTraceConfig};
 use dslab_faas::resource::ResourceProvider;
 use dslab_faas::simulation::ServerlessSimulation;
@@ -26,7 +26,7 @@ fn main() {
     };
     let trace = process_opendc_trace(Path::new(&args.trace), trace_config);
     let config = Config {
-        cpu_policy: Box::<IgnoredCPUPolicy>::default(),
+        cpu_policy: Box::<IgnoredCpuPolicy>::default(),
         coldstart_policy: Box::new(FixedTimeColdStartPolicy::new(120.0 * 60.0, 0.0)),
         ..Default::default()
     };

--- a/examples/faas-parallel/src/main.rs
+++ b/examples/faas-parallel/src/main.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use clap::Parser;
 
 use dslab_faas::coldstart::{ColdStartPolicy, FixedTimeColdStartPolicy};
-use dslab_faas::extra::azure_trace::{process_azure_trace, AzureTraceConfig};
+use dslab_faas::extra::azure_trace::{process_azure_trace, AppPreference, AzureTraceConfig};
 use dslab_faas::parallel::{parallel_simulation, ParallelConfig, ParallelHostConfig};
 
 #[derive(Parser, Debug)]
@@ -16,7 +16,8 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let trace_config = AzureTraceConfig {
-        invocations_limit: 20000,
+        time_period: 60 * 20,
+        app_preferences: vec![AppPreference::new(60, 0.45, 0.55)],
         ..Default::default()
     };
     let trace = Box::new(process_azure_trace(Path::new(&args.trace), trace_config));

--- a/examples/faas-scheduling-experiment/Cargo.toml
+++ b/examples/faas-scheduling-experiment/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 clap = { version = "4.1.1", features = ["derive"] }
 dslab-core = { path = "../../crates/dslab-core" }
 dslab-faas = { path = "../../crates/dslab-faas" }
+plotters = "0.3.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/examples/faas-scheduling-experiment/config.yaml
+++ b/examples/faas-scheduling-experiment/config.yaml
@@ -6,7 +6,7 @@ base_config:
           quantity: 26624
       invoker: FIFOInvoker
       count: 8
-  coldstart_policy: FixedTimeColdStartPolicy[keepalive=600,prewarm=0]
+  coldstart_policy: FixedTimeColdStartPolicy[keepalive=900,prewarm=0]
   idle_deployer: BasicDeployer
   disable_contention: false
 schedulers:

--- a/examples/faas-scheduling-experiment/config.yaml
+++ b/examples/faas-scheduling-experiment/config.yaml
@@ -6,13 +6,13 @@ base_config:
           quantity: 26624
       invoker: FIFOInvoker
       count: 8
-  coldstart_policy: FixedTimeColdStartPolicy[keepalive=900,prewarm=0]
+  coldstart_policy: FixedTimeColdStartPolicy[keepalive=600,prewarm=0]
+  cpu_policy: isolated
   idle_deployer: BasicDeployer
-  disable_contention: false
 schedulers:
   - LocalityBasedScheduler[warm_only=true]
   - LocalityBasedScheduler[warm_only=false]
   - RandomScheduler[seed=1]
-  - LeastLoadedScheduler[prefer_warm=true,use_invocation_count=true,avoid_queueing=true]
+  - LeastLoadedScheduler[prefer_warm=false,use_invocation_count=true,avoid_queueing=false]
   - RoundRobinScheduler
-  - HermesScheduler[use_invocation_count=true,avoid_queueing=true]
+  - HermesScheduler[use_invocation_count=true,avoid_queueing=false]

--- a/examples/faas-scheduling-experiment/config.yaml
+++ b/examples/faas-scheduling-experiment/config.yaml
@@ -4,9 +4,9 @@ base_config:
       resources:
         - name: mem
           quantity: 26624
-      invoker: BasicInvoker
+      invoker: FIFOInvoker
       count: 9
-  coldstart_policy: FixedTimeColdStartPolicy[keepalive=1200,prewarm=0]
+  coldstart_policy: FixedTimeColdStartPolicy[keepalive=600,prewarm=0]
   idle_deployer: BasicDeployer
   disable_contention: false
 schedulers:

--- a/examples/faas-scheduling-experiment/config.yaml
+++ b/examples/faas-scheduling-experiment/config.yaml
@@ -5,7 +5,7 @@ base_config:
         - name: mem
           quantity: 26624
       invoker: FIFOInvoker
-      count: 9
+      count: 8
   coldstart_policy: FixedTimeColdStartPolicy[keepalive=600,prewarm=0]
   idle_deployer: BasicDeployer
   disable_contention: false
@@ -13,6 +13,6 @@ schedulers:
   - LocalityBasedScheduler[warm_only=true]
   - LocalityBasedScheduler[warm_only=false]
   - RandomScheduler[seed=1]
-  - LeastLoadedScheduler[prefer_warm=true,use_invocation_count=true,avoid_queueing=false]
+  - LeastLoadedScheduler[prefer_warm=true,use_invocation_count=true,avoid_queueing=true]
   - RoundRobinScheduler
   - HermesScheduler[use_invocation_count=true,avoid_queueing=true]

--- a/examples/faas-scheduling-experiment/readme.md
+++ b/examples/faas-scheduling-experiment/readme.md
@@ -1,9 +1,9 @@
 # FaaS scheduling experiment
-This example evaluates different approaches for scheduling of function invocations (several simple strategies and [Hermes](https://arxiv.org/abs/2111.07226) scheduler) on Azure functions dataset.
+This example evaluates different approaches for scheduling of function invocations (several simple strategies and [Hermes](https://arxiv.org/abs/2111.07226) scheduler) on Azure functions dataset. The experiment is similar to the one used in Hermes paper.
 ## Running experiment
 - download and unpack Azure functions [dataset](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsDataset2019.md)
 - build
-- run `faas-scheduling-experiment %path_to_dataset% --config %config%`
+- run `faas-scheduling-experiment %path_to_dataset% --config %config% --plot %output_plot_file%`
 
 It is recommended to build strictly in release mode and leave only one day out of 14 since the dataset is really large.
 Note that the last two days in the dataset have no memory percentiles. Such days are ignored.

--- a/examples/faas-scheduling-experiment/src/main.rs
+++ b/examples/faas-scheduling-experiment/src/main.rs
@@ -1,3 +1,5 @@
+mod plot;
+
 use std::boxed::Box;
 use std::fs::File;
 use std::path::Path;
@@ -10,6 +12,8 @@ use dslab_faas::config::{ConfigParamResolvers, RawConfig};
 use dslab_faas::extra::azure_trace::{process_azure_trace, AppPreference, AzureTraceConfig, DurationGenerator};
 use dslab_faas::extra::resolvers::{extra_coldstart_policy_resolver, extra_scheduler_resolver};
 use dslab_faas::parallel::parallel_simulation_raw;
+
+use crate::plot::plot_results;
 
 #[derive(Serialize, Deserialize)]
 struct ExperimentConfig {
@@ -25,40 +29,55 @@ struct Args {
     /// Path to a simulation config in YAML format.
     #[arg(long)]
     config: String,
+    /// Plot output path.
+    #[arg(long)]
+    plot: String,
 }
+
 fn main() {
     let args = Args::parse();
-    let trace_config = AzureTraceConfig {
-        time_period: 60,
-        duration_generator: DurationGenerator::PrefittedLognormal,
-        app_preferences: vec![AppPreference::new(1, 0., 0.05), AppPreference::new(49, 0.45, 0.55)],
-        force_fixed_memory: Some(256),
-        ..Default::default()
-    };
-    let trace = Box::new(process_azure_trace(Path::new(&args.trace), trace_config));
-    println!(
-        "trace processed successfully, {} invocations",
-        trace.trace_records.len()
-    );
     let experiment_config: ExperimentConfig =
         serde_yaml::from_reader(File::open(Path::new(&args.config)).unwrap()).unwrap();
     let schedulers = experiment_config.schedulers;
     let base_config = experiment_config.base_config;
-    let configs: Vec<_> = schedulers
-        .iter()
-        .map(|x| {
-            let mut config = base_config.clone();
-            config.scheduler = x.to_string();
-            config
-        })
-        .collect();
-    let resolvers = ConfigParamResolvers {
-        coldstart_policy_resolver: Box::new(extra_coldstart_policy_resolver),
-        scheduler_resolver: Box::new(extra_scheduler_resolver),
-        ..Default::default()
-    };
-    let mut stats = parallel_simulation_raw(configs, resolvers, vec![trace], vec![1]);
-    for (i, s) in stats.drain(..).enumerate() {
-        s.global_stats.print_summary(&schedulers[i]);
+    let rps_vec = (1..15).map(|x| x as f64).collect::<Vec<f64>>();
+    let mut points = vec![Vec::with_capacity(rps_vec.len()); schedulers.len()];
+    for rps in rps_vec.iter() {
+        let trace_config = AzureTraceConfig {
+            time_period: 60,
+            duration_generator: DurationGenerator::PrefittedLognormal,
+            app_preferences: vec![AppPreference::new(1, 0., 0.05), AppPreference::new(49, 0.45, 0.55)],
+            force_fixed_memory: Some(256),
+            rps: Some(*rps),
+            ..Default::default()
+        };
+        let trace = Box::new(process_azure_trace(Path::new(&args.trace), trace_config));
+        println!(
+            "trace processed successfully, got {} invocations at {} RPS",
+            trace.trace_records.len(),
+            *rps
+        );
+        let configs: Vec<_> = schedulers
+            .iter()
+            .map(|x| {
+                let mut config = base_config.clone();
+                config.scheduler = x.to_string();
+                config
+            })
+            .collect();
+        let resolvers = ConfigParamResolvers {
+            coldstart_policy_resolver: Box::new(extra_coldstart_policy_resolver),
+            scheduler_resolver: Box::new(extra_scheduler_resolver),
+            ..Default::default()
+        };
+        let mut stats = parallel_simulation_raw(configs, resolvers, vec![trace], vec![1]);
+        for (i, s) in stats.drain(..).enumerate() {
+            let inv = s.global_stats.invocation_stats;
+            points[i].push([
+                inv.rel_total_slowdown.quantile(0.99),
+                (inv.cold_starts as f64) / (inv.invocations as f64) * 100.,
+            ]);
+        }
     }
+    plot_results(&args.plot, &schedulers, &rps_vec, &points);
 }

--- a/examples/faas-scheduling-experiment/src/main.rs
+++ b/examples/faas-scheduling-experiment/src/main.rs
@@ -1,6 +1,7 @@
 mod plot;
 
 use std::boxed::Box;
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
@@ -14,6 +15,7 @@ use dslab_faas::extra::azure_trace::{
 };
 use dslab_faas::extra::resolvers::{extra_coldstart_policy_resolver, extra_scheduler_resolver};
 use dslab_faas::parallel::parallel_simulation_raw;
+use dslab_faas::trace::Trace;
 
 use crate::plot::plot_results;
 
@@ -49,7 +51,7 @@ fn main() {
             time_period: 60,
             duration_generator: DurationGenerator::PrefittedLognormal,
             start_generator: StartGenerator::PoissonFit,
-            app_preferences: vec![AppPreference::new(1, 0., 0.05), AppPreference::new(49, 0.45, 0.55)],
+            app_preferences: vec![AppPreference::new(1, 0.02, 0.05), AppPreference::new(49, 0.45, 0.55)],
             force_fixed_memory: Some(256),
             rps: Some(*rps),
             ..Default::default()
@@ -77,7 +79,7 @@ fn main() {
         for (i, s) in stats.drain(..).enumerate() {
             let inv = s.global_stats.invocation_stats;
             points[i].push([
-                inv.rel_total_slowdown.quantile(0.99),
+                inv.rel_total_slowdown.quantile(0.99) + 1.,
                 (inv.cold_starts as f64) / (inv.invocations as f64) * 100.,
             ]);
         }

--- a/examples/faas-scheduling-experiment/src/main.rs
+++ b/examples/faas-scheduling-experiment/src/main.rs
@@ -1,7 +1,6 @@
 mod plot;
 
 use std::boxed::Box;
-use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
@@ -15,7 +14,6 @@ use dslab_faas::extra::azure_trace::{
 };
 use dslab_faas::extra::resolvers::{extra_coldstart_policy_resolver, extra_scheduler_resolver};
 use dslab_faas::parallel::parallel_simulation_raw;
-use dslab_faas::trace::Trace;
 
 use crate::plot::plot_results;
 

--- a/examples/faas-scheduling-experiment/src/main.rs
+++ b/examples/faas-scheduling-experiment/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 
 use dslab_faas::config::{ConfigParamResolvers, RawConfig};
-use dslab_faas::extra::azure_trace::{process_azure_trace, AzureTraceConfig};
+use dslab_faas::extra::azure_trace::{process_azure_trace, AppPreference, AzureTraceConfig, DurationGenerator};
 use dslab_faas::extra::resolvers::{extra_coldstart_policy_resolver, extra_scheduler_resolver};
 use dslab_faas::parallel::parallel_simulation_raw;
 
@@ -29,7 +29,9 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let trace_config = AzureTraceConfig {
-        invocations_limit: 100000,
+        time_period: 60,
+        duration_generator: DurationGenerator::PrefittedLognormal,
+        app_preferences: vec![AppPreference::new(1, 0., 0.05), AppPreference::new(49, 0.45, 0.55)],
         force_fixed_memory: Some(256),
         ..Default::default()
     };

--- a/examples/faas-scheduling-experiment/src/main.rs
+++ b/examples/faas-scheduling-experiment/src/main.rs
@@ -9,7 +9,9 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 
 use dslab_faas::config::{ConfigParamResolvers, RawConfig};
-use dslab_faas::extra::azure_trace::{process_azure_trace, AppPreference, AzureTraceConfig, DurationGenerator};
+use dslab_faas::extra::azure_trace::{
+    process_azure_trace, AppPreference, AzureTraceConfig, DurationGenerator, StartGenerator,
+};
 use dslab_faas::extra::resolvers::{extra_coldstart_policy_resolver, extra_scheduler_resolver};
 use dslab_faas::parallel::parallel_simulation_raw;
 
@@ -46,6 +48,7 @@ fn main() {
         let trace_config = AzureTraceConfig {
             time_period: 60,
             duration_generator: DurationGenerator::PrefittedLognormal,
+            start_generator: StartGenerator::PoissonFit,
             app_preferences: vec![AppPreference::new(1, 0., 0.05), AppPreference::new(49, 0.45, 0.55)],
             force_fixed_memory: Some(256),
             rps: Some(*rps),

--- a/examples/faas-scheduling-experiment/src/plot.rs
+++ b/examples/faas-scheduling-experiment/src/plot.rs
@@ -26,8 +26,9 @@ pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &
             .fold(0., f64::max)
             * 1.1;
         let mut ctx = ChartBuilder::on(&areas[idx])
+            .margin(20)
             .set_label_area_size(LabelAreaPosition::Left, 60)
-            .set_label_area_size(LabelAreaPosition::Bottom, 60)
+            .set_label_area_size(LabelAreaPosition::Bottom, 30)
             .build_cartesian_2d(rps[0]..rps.last().copied().unwrap(), 0.0..f64::min(max, 100.))
             .unwrap();
         ctx.configure_mesh()

--- a/examples/faas-scheduling-experiment/src/plot.rs
+++ b/examples/faas-scheduling-experiment/src/plot.rs
@@ -25,16 +25,10 @@ pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &
             .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
             .fold(0., f64::max)
             * 1.1;
-        /*let repr = points
-        .iter()
-        .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
-        .fold(f64::MAX, f64::min)
-        * 2.;*/
-        let repr = 100.;
         let mut ctx = ChartBuilder::on(&areas[idx])
             .set_label_area_size(LabelAreaPosition::Left, 60)
             .set_label_area_size(LabelAreaPosition::Bottom, 60)
-            .build_cartesian_2d(rps[0]..rps.last().copied().unwrap(), 0.0..f64::min(max, repr))
+            .build_cartesian_2d(rps[0]..rps.last().copied().unwrap(), 0.0..f64::min(max, 100.))
             .unwrap();
         ctx.configure_mesh()
             .y_desc(METRICS[idx])

--- a/examples/faas-scheduling-experiment/src/plot.rs
+++ b/examples/faas-scheduling-experiment/src/plot.rs
@@ -28,12 +28,13 @@ pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &
         let mut ctx = ChartBuilder::on(&areas[idx])
             .margin(20)
             .set_label_area_size(LabelAreaPosition::Left, 60)
-            .set_label_area_size(LabelAreaPosition::Bottom, 30)
+            .set_label_area_size(LabelAreaPosition::Bottom, 40)
             .build_cartesian_2d(rps[0]..rps.last().copied().unwrap(), 0.0..f64::min(max, 100.))
             .unwrap();
         ctx.configure_mesh()
             .y_desc(METRICS[idx])
             .x_desc("requests per second")
+            .label_style(("sans-serif", 20))
             .draw()
             .unwrap();
         for (i, pts) in points.iter().enumerate() {
@@ -49,6 +50,7 @@ pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &
             .position(SeriesLabelPosition::UpperLeft)
             .border_style(BLACK)
             .background_style(WHITE.mix(0.8))
+            .label_font(("sans-serif", 20))
             .draw()
             .unwrap();
     }

--- a/examples/faas-scheduling-experiment/src/plot.rs
+++ b/examples/faas-scheduling-experiment/src/plot.rs
@@ -5,15 +5,9 @@ use plotters::prelude::*;
 const METRICS: &[&str] = &["99% relative slowdown", "cold start fraction (%)"];
 
 pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &[Vec<[f64; 2]>]) {
-    let side = (labels.len() as f64).cbrt().ceil() as usize;
-    let step = 200 / side;
     let mut styles = Vec::with_capacity(labels.len());
     for i in 0..labels.len() {
-        let r = ((i % side) * step + 20) as u8;
-        let tmp = i / side;
-        let g = ((tmp % side) * step + 20) as u8;
-        let b = ((tmp / side) * step + 20) as u8;
-        styles.push(Into::<ShapeStyle>::into(RGBColor(r, g, b)).filled());
+        styles.push(Into::<ShapeStyle>::into(Palette99::pick(i)).filled());
     }
     let root_area = BitMapBackend::new(plot, (1600, 900)).into_drawing_area();
     root_area.fill(&WHITE).unwrap();

--- a/examples/faas-scheduling-experiment/src/plot.rs
+++ b/examples/faas-scheduling-experiment/src/plot.rs
@@ -2,7 +2,7 @@ use std::iter::zip;
 
 use plotters::prelude::*;
 
-const METRICS: &[&str] = &["99% slowdown (s)", "cold start fraction (%)"];
+const METRICS: &[&str] = &["99% relative slowdown", "cold start fraction (%)"];
 
 pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &[Vec<[f64; 2]>]) {
     let side = (labels.len() as f64).cbrt().ceil() as usize;
@@ -25,11 +25,12 @@ pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &
             .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
             .fold(0., f64::max)
             * 1.1;
-        let repr = points
-            .iter()
-            .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
-            .fold(f64::MAX, f64::min)
-            * 2.;
+        /*let repr = points
+        .iter()
+        .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
+        .fold(f64::MAX, f64::min)
+        * 2.;*/
+        let repr = 100.;
         let mut ctx = ChartBuilder::on(&areas[idx])
             .set_label_area_size(LabelAreaPosition::Left, 60)
             .set_label_area_size(LabelAreaPosition::Bottom, 60)

--- a/examples/faas-scheduling-experiment/src/plot.rs
+++ b/examples/faas-scheduling-experiment/src/plot.rs
@@ -1,0 +1,59 @@
+use std::iter::zip;
+
+use plotters::prelude::*;
+
+const METRICS: &[&str] = &["99% slowdown (s)", "cold start fraction (%)"];
+
+pub(crate) fn plot_results(plot: &str, labels: &[String], rps: &[f64], points: &[Vec<[f64; 2]>]) {
+    let side = (labels.len() as f64).cbrt().ceil() as usize;
+    let step = 200 / side;
+    let mut styles = Vec::with_capacity(labels.len());
+    for i in 0..labels.len() {
+        let r = ((i % side) * step + 20) as u8;
+        let tmp = i / side;
+        let g = ((tmp % side) * step + 20) as u8;
+        let b = ((tmp / side) * step + 20) as u8;
+        styles.push(Into::<ShapeStyle>::into(RGBColor(r, g, b)).filled());
+    }
+    let root_area = BitMapBackend::new(plot, (1600, 900)).into_drawing_area();
+    root_area.fill(&WHITE).unwrap();
+    let tmp = root_area.split_vertically((50).percent());
+    let areas: [_; 2] = [tmp.0, tmp.1];
+    for idx in 0..2 {
+        let max = points
+            .iter()
+            .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
+            .fold(0., f64::max)
+            * 1.1;
+        let repr = points
+            .iter()
+            .map(|v| v.iter().fold(0., |acc, x| f64::max(acc, x[idx])))
+            .fold(f64::MAX, f64::min)
+            * 2.;
+        let mut ctx = ChartBuilder::on(&areas[idx])
+            .set_label_area_size(LabelAreaPosition::Left, 60)
+            .set_label_area_size(LabelAreaPosition::Bottom, 60)
+            .build_cartesian_2d(rps[0]..rps.last().copied().unwrap(), 0.0..f64::min(max, repr))
+            .unwrap();
+        ctx.configure_mesh()
+            .y_desc(METRICS[idx])
+            .x_desc("requests per second")
+            .draw()
+            .unwrap();
+        for (i, pts) in points.iter().enumerate() {
+            let style = styles[i];
+            ctx.draw_series(
+                LineSeries::new(zip(rps.iter(), pts.iter()).map(|(x, y)| (*x, y[idx])), style).point_size(5),
+            )
+            .unwrap()
+            .label(labels[i].clone())
+            .legend(move |pos| Circle::new(pos, 5, style));
+        }
+        ctx.configure_series_labels()
+            .position(SeriesLabelPosition::UpperLeft)
+            .border_style(BLACK)
+            .background_style(WHITE.mix(0.8))
+            .draw()
+            .unwrap();
+    }
+}

--- a/examples/serverless-in-the-wild/Cargo.toml
+++ b/examples/serverless-in-the-wild/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 clap = { version = "4.1.1", features = ["derive"] }
 dslab-core = { path = "../../crates/dslab-core" }
 dslab-faas = { path = "../../crates/dslab-faas" }
+plotters = "0.3.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/examples/serverless-in-the-wild/config.yaml
+++ b/examples/serverless-in-the-wild/config.yaml
@@ -1,11 +1,11 @@
 base_config:
   hosts:
-    - cores: 8
+    - cores: 2
       resources:
         - name: mem
-          quantity: 16384
+          quantity: 4096
       invoker: BasicInvoker
-      count: 1000
+      count: 18
   scheduler: BasicScheduler
   idle_deployer: BasicDeployer
   disable_contention: false

--- a/examples/serverless-in-the-wild/config.yaml
+++ b/examples/serverless-in-the-wild/config.yaml
@@ -4,7 +4,7 @@ base_config:
       resources:
         - name: mem
           quantity: 4096
-      invoker: BasicInvoker
+      invoker: FIFOInvoker
       count: 18
   scheduler: BasicScheduler
   idle_deployer: BasicDeployer

--- a/examples/serverless-in-the-wild/config.yaml
+++ b/examples/serverless-in-the-wild/config.yaml
@@ -11,7 +11,6 @@ base_config:
   cpu_policy: contended
 coldstart_policies:
   - No unloading
-  - 5-minute keepalive
   - 10-minute keepalive
   - 20-minute keepalive
   - 30-minute keepalive

--- a/examples/serverless-in-the-wild/config.yaml
+++ b/examples/serverless-in-the-wild/config.yaml
@@ -8,7 +8,7 @@ base_config:
       count: 18
   scheduler: BasicScheduler
   idle_deployer: BasicDeployer
-  disable_contention: false
+  cpu_policy: contended
 coldstart_policies:
   - No unloading
   - 5-minute keepalive

--- a/examples/serverless-in-the-wild/config.yaml
+++ b/examples/serverless-in-the-wild/config.yaml
@@ -11,11 +11,15 @@ base_config:
   disable_contention: false
 coldstart_policies:
   - No unloading
+  - 5-minute keepalive
+  - 10-minute keepalive
   - 20-minute keepalive
+  - 30-minute keepalive
   - 45-minute keepalive
   - 60-minute keepalive
   - 90-minute keepalive
   - 120-minute keepalive
+  - Hybrid Histogram policy, 1 hour bound
   - Hybrid Histogram policy, 2 hours bound
   - Hybrid Histogram policy, 3 hours bound
   - Hybrid Histogram policy, 4 hours bound

--- a/examples/serverless-in-the-wild/readme.md
+++ b/examples/serverless-in-the-wild/readme.md
@@ -1,9 +1,11 @@
 # Serverless in the Wild reproduction
 This crate reproduces the experiments with keepalive policies from [Serverless in the Wild](https://www.usenix.org/conference/atc20/presentation/shahrad) paper.
+
+Note that console output is just a default description of simulation results, for paper-related results you should specify `--plot` option. In this case the program will make a plot of relevant metrics.
 ## Steps to reproduce
 - download and unpack Azure functions [dataset](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsDataset2019.md)
 - build
-- run `serverless-in-the-wild %path_to_dataset% --config %config%`
+- run `serverless-in-the-wild %path_to_dataset% --config %config% --plot %plot_name%`
 
 It is recommended to build strictly in release mode and leave only one day out of 14 since the dataset is really large.
 Note that the last two days in the dataset have no memory percentiles. Such days are ignored.

--- a/examples/serverless-in-the-wild/readme.md
+++ b/examples/serverless-in-the-wild/readme.md
@@ -5,7 +5,7 @@ Note that console output is just a default description of simulation results, fo
 ## Steps to reproduce
 - download and unpack Azure functions [dataset](https://github.com/Azure/AzurePublicDataset/blob/master/AzureFunctionsDataset2019.md)
 - build
-- run `serverless-in-the-wild %path_to_dataset% --config %config% --plot %plot_name%`
+- run `serverless-in-the-wild %path_to_dataset% --config %config% --plot %output_plot_file%`
 
 It is recommended to build strictly in release mode and leave only one day out of 14 since the dataset is really large.
 Note that the last two days in the dataset have no memory percentiles. Such days are ignored.

--- a/examples/serverless-in-the-wild/src/main.rs
+++ b/examples/serverless-in-the-wild/src/main.rs
@@ -90,12 +90,12 @@ fn main() {
         s.global_stats.print_summary(&policies[i]);
         if args.plot.is_some() {
             let mut apps: SampleMetric = Default::default();
-            for (_, app_stats) in s.app_stats.iter() {
+            for app_stats in s.app_stats.iter() {
                 apps.add((app_stats.cold_starts as f64) / (app_stats.invocations as f64) * 100.);
             }
             results.push((
                 apps.quantile(0.75),
-                s.global_stats.wasted_resource_time.get(&0).unwrap().sum(),
+                s.global_stats.wasted_resource_time.get(0).unwrap().sum(),
             ));
         }
     }

--- a/examples/serverless-in-the-wild/src/main.rs
+++ b/examples/serverless-in-the-wild/src/main.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use dslab_faas::coldstart::{ColdStartPolicy, FixedTimeColdStartPolicy};
 use dslab_faas::config::{ConfigParamResolvers, RawConfig};
-use dslab_faas::extra::azure_trace::{process_azure_trace, AzureTraceConfig};
+use dslab_faas::extra::azure_trace::{process_azure_trace, AppPreference, AzureTraceConfig};
 use dslab_faas::extra::hybrid_histogram::HybridHistogramPolicy;
 use dslab_faas::parallel::parallel_simulation_raw;
 
@@ -50,7 +50,8 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let trace_config = AzureTraceConfig {
-        invocations_limit: 200000,
+        time_period: 8 * 60,
+        app_preferences: vec![AppPreference::new(68, 0.45, 0.55)],
         concurrency_level: 16,
         ..Default::default()
     };

--- a/examples/serverless-in-the-wild/src/main.rs
+++ b/examples/serverless-in-the-wild/src/main.rs
@@ -2,6 +2,7 @@ mod plot;
 
 use std::boxed::Box;
 use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 
 use clap::Parser;
@@ -53,6 +54,9 @@ struct Args {
     /// Plot output path (if needed).
     #[arg(long)]
     plot: Option<String>,
+    /// Dump final metrics to given file.
+    #[arg(long)]
+    dump: Option<String>,
 }
 
 fn main() {
@@ -97,6 +101,13 @@ fn main() {
                 apps.quantile(0.75),
                 s.global_stats.wasted_resource_time.get(0).unwrap().sum(),
             ));
+        }
+    }
+    if let Some(s) = args.dump {
+        let mut out = File::create(s).unwrap();
+        writeln!(&mut out, "policy,75% app coldstart frequency,wasted memory time").unwrap();
+        for (policy, result) in std::iter::zip(policies.iter(), results.iter()) {
+            writeln!(&mut out, "{},{:.4},{:.4}", policy, result.0, result.1).unwrap();
         }
     }
     if let Some(plot) = args.plot {

--- a/examples/serverless-in-the-wild/src/plot.rs
+++ b/examples/serverless-in-the-wild/src/plot.rs
@@ -1,0 +1,54 @@
+use plotters::prelude::*;
+
+pub(crate) fn plot_results(plot: &str, mut labels: Vec<String>, mut points: Vec<(f64, f64)>) {
+    if let Some(ban) = labels.iter().position(|x| x.contains("unloading")) {
+        // can't plot no unloading policy because of infinite wasted memory
+        labels.remove(ban);
+        points.remove(ban);
+    }
+    let max_cold_start = 1.01 * points.iter().fold(0., |acc, x| f64::max(x.0, acc));
+    let min_wasted_mem = points.iter().fold(f64::MAX, |acc, x| f64::min(x.1, acc)) - 1.;
+    let max_wasted_mem = points.iter().fold(0., |acc, x| f64::max(x.1, acc)) + 1.;
+    let root_area = BitMapBackend::new(plot, (1600, 900)).into_drawing_area();
+    root_area.fill(&WHITE).unwrap();
+    let mut ctx = ChartBuilder::on(&root_area)
+        .set_label_area_size(LabelAreaPosition::Left, 60)
+        .set_label_area_size(LabelAreaPosition::Bottom, 60)
+        .build_cartesian_2d(0. ..max_cold_start, min_wasted_mem..max_wasted_mem)
+        .unwrap();
+    ctx.configure_mesh()
+        .y_desc("normalized wasted memory time (%)")
+        .x_desc("3rd quartile app cold start percentage (%)")
+        .draw()
+        .unwrap();
+    let side = (labels.len() as f64).cbrt().ceil() as usize;
+    let step = 200 / side;
+    for i in 0..labels.len() {
+        let r = ((i % side) * step + 20) as u8;
+        let tmp = i / side;
+        let g = ((tmp % side) * step + 20) as u8;
+        let b = ((tmp / side) * step + 20) as u8;
+        if labels[i].contains("unloading") {
+            continue;
+        } else if labels[i].contains("keepalive") {
+            ctx.draw_series([TriangleMarker::new(points[i], 5, RGBColor(r, g, b))])
+                .unwrap()
+                .label(labels[i].clone())
+                .legend(move |pos| TriangleMarker::new(pos, 5, RGBColor(r, g, b)));
+        } else {
+            ctx.draw_series([Circle::new(
+                points[i],
+                5,
+                Into::<ShapeStyle>::into(RGBColor(r, g, b)).filled(),
+            )])
+            .unwrap()
+            .label(labels[i].clone())
+            .legend(move |pos| Circle::new(pos, 5, Into::<ShapeStyle>::into(RGBColor(r, g, b)).filled()));
+        }
+    }
+    ctx.configure_series_labels()
+        .border_style(&BLACK)
+        .background_style(&WHITE.mix(0.8))
+        .draw()
+        .unwrap();
+}

--- a/examples/serverless-in-the-wild/src/plot.rs
+++ b/examples/serverless-in-the-wild/src/plot.rs
@@ -12,13 +12,14 @@ pub(crate) fn plot_results(plot: &str, mut labels: Vec<String>, mut points: Vec<
     let root_area = BitMapBackend::new(plot, (1600, 900)).into_drawing_area();
     root_area.fill(&WHITE).unwrap();
     let mut ctx = ChartBuilder::on(&root_area)
-        .set_label_area_size(LabelAreaPosition::Left, 60)
-        .set_label_area_size(LabelAreaPosition::Bottom, 60)
+        .set_label_area_size(LabelAreaPosition::Left, 70)
+        .set_label_area_size(LabelAreaPosition::Bottom, 50)
         .build_cartesian_2d(0. ..max_cold_start, min_wasted_mem..max_wasted_mem)
         .unwrap();
     ctx.configure_mesh()
         .y_desc("normalized wasted memory time (%)")
         .x_desc("3rd quartile app cold start percentage (%)")
+        .label_style(("sans-serif", 20))
         .draw()
         .unwrap();
     let side = (labels.len() as f64).cbrt().ceil() as usize;
@@ -47,6 +48,7 @@ pub(crate) fn plot_results(plot: &str, mut labels: Vec<String>, mut points: Vec<
         }
     }
     ctx.configure_series_labels()
+        .label_font(("sans-serif", 20))
         .border_style(BLACK)
         .background_style(WHITE.mix(0.8))
         .draw()

--- a/examples/serverless-in-the-wild/src/plot.rs
+++ b/examples/serverless-in-the-wild/src/plot.rs
@@ -22,29 +22,23 @@ pub(crate) fn plot_results(plot: &str, mut labels: Vec<String>, mut points: Vec<
         .label_style(("sans-serif", 20))
         .draw()
         .unwrap();
-    let side = (labels.len() as f64).cbrt().ceil() as usize;
-    let step = 200 / side;
     for i in 0..labels.len() {
-        let r = ((i % side) * step + 20) as u8;
-        let tmp = i / side;
-        let g = ((tmp % side) * step + 20) as u8;
-        let b = ((tmp / side) * step + 20) as u8;
         if labels[i].contains("unloading") {
             continue;
         } else if labels[i].contains("keepalive") {
-            ctx.draw_series([TriangleMarker::new(points[i], 5, RGBColor(r, g, b))])
+            ctx.draw_series([TriangleMarker::new(points[i], 8, Palette99::pick(i))])
                 .unwrap()
                 .label(labels[i].clone())
-                .legend(move |pos| TriangleMarker::new(pos, 5, RGBColor(r, g, b)));
+                .legend(move |pos| TriangleMarker::new(pos, 8, Palette99::pick(i)));
         } else {
             ctx.draw_series([Circle::new(
                 points[i],
-                5,
-                Into::<ShapeStyle>::into(RGBColor(r, g, b)).filled(),
+                8,
+                Into::<ShapeStyle>::into(Palette99::pick(i)).filled(),
             )])
             .unwrap()
             .label(labels[i].clone())
-            .legend(move |pos| Circle::new(pos, 5, Into::<ShapeStyle>::into(RGBColor(r, g, b)).filled()));
+            .legend(move |pos| Circle::new(pos, 8, Into::<ShapeStyle>::into(Palette99::pick(i)).filled()));
         }
     }
     ctx.configure_series_labels()

--- a/examples/serverless-in-the-wild/src/plot.rs
+++ b/examples/serverless-in-the-wild/src/plot.rs
@@ -47,8 +47,8 @@ pub(crate) fn plot_results(plot: &str, mut labels: Vec<String>, mut points: Vec<
         }
     }
     ctx.configure_series_labels()
-        .border_style(&BLACK)
-        .background_style(&WHITE.mix(0.8))
+        .border_style(BLACK)
+        .background_style(WHITE.mix(0.8))
         .draw()
         .unwrap();
 }


### PR DESCRIPTION
- Полностью переделал генерацию эксперимента для лучшего соответствия статьям
- Добавил графики в serverless-in-the-wild и faas-scheduling-experiment
- Добавил FIFOInvoker, который работает гораздо быстрее в случае больших очередей
- Добавил трейт CPUPolicy с 3 реализациями: Ignored, Contended (соответствуют тому, что было раньше при разных значениях disable_contention) и Isolated (строгая изоляция по ядрам). Пока здесь сделано не всё, что хочу, но остальное будет в другой ветке