### PR TITLE
[mp] use object_hook for python deserialize

### DIFF
--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -5,11 +5,11 @@ class DataClass:
     def __init__(self, x=42):
         self.data = x
 
-    def toJSON(self):
+    def serialize(self):
         return {'value': self.data}
 
     @staticmethod
-    def fromJSON(data):
+    def deserialize(data):
         return DataClass(data['value'])
 
 

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -48,8 +48,8 @@ class TestProcess(Process):
         except AttributeError:
             return
         except:
-            raise 'Incorrect exception raised when addressing not-existing member'
-        raise 'No exception raised when addressing not-existing member'
+            raise Exception('Incorrect exception raised when addressing not-existing member')
+        raise Exception('No exception raised when addressing not-existing member')
 
     def on_message(self, msg: Message, sender: str, ctx: Context):
         # process messages from server

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -1,4 +1,18 @@
-from dslabmp import Context, Message, Process, StateMember
+from dslabmp import Context, Message, Process, StateMember, Serialize
+
+
+class DataClass:
+    def __init__(self, x=42):
+        self.data = x
+
+    @staticmethod
+    @Serialize
+    def toJSON(self):
+        return {'value': self.data}
+
+    @staticmethod
+    def fromJSON(data):
+        return DataClass(data['value'])
 
 
 class TestProcess(Process):
@@ -6,6 +20,7 @@ class TestProcess(Process):
         self.data = StateMember(["elem1", (2, 3), {'key': 'value'}])
         self._id = StateMember(node_id)
         self.messages = StateMember([Message('GET', '')])
+        self.inner_member = StateMember(DataClass())
 
         # examples of set/get state member
         self._id = 'new_node_id'
@@ -31,7 +46,7 @@ class TestProcess(Process):
         assert self.messages is not None
         assert type(self.messages) == list
         assert type(self.messages[0]) == Message
-
+        assert self.inner_member.data == 42
         try:
             a = self.notexists
         except AttributeError:

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -17,7 +17,7 @@ class TestProcess(Process):
     def __init__(self, node_id: str):
         self.data = StateMember(["elem1", (2, 3), {'key': 'value'}])
         self._id = StateMember(node_id)
-        self.messages = StateMember([Message('GET', '')])
+        self.messages = StateMember([Message('GET', '""')])
         self.inner_member = StateMember(DataClass())
 
         # examples of set/get state member

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -3,8 +3,9 @@ from dslabmp import Context, Message, Process, StateMember
 
 class TestProcess(Process):
     def __init__(self, node_id: str):
-        self.data = StateMember(["elem1", (2, 3)])
+        self.data = StateMember(["elem1", (2, 3), {'key': 'value'}])
         self._id = StateMember(node_id)
+        self.messages = StateMember([Message('GET', '')])
 
         # examples of set/get state member
         self._id = 'new_node_id'
@@ -27,12 +28,16 @@ class TestProcess(Process):
         else:
             ctx.send_local(msg)
 
+        assert self.messages is not None
+        assert type(self.messages) == list
+        assert type(self.messages[0]) == Message
+
         try:
             a = self.notexists
         except AttributeError:
             return
         except:
-            raise 'Not a correct exception raised when addressing not-existing member'
+            raise 'Incorrect exception raised when addressing not-existing member'
         raise 'No exception raised when addressing not-existing member'
 
     def on_message(self, msg: Message, sender: str, ctx: Context):

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -17,7 +17,7 @@ class TestProcess(Process):
     def __init__(self, node_id: str):
         self.data = StateMember(["elem1", (2, 3), {'key': 'value'}])
         self._id = StateMember(node_id)
-        self.messages = StateMember([Message('GET', '""')])
+        self.messages = StateMember([Message('GET', {})])
         self.inner_member = StateMember(DataClass())
 
         # examples of set/get state member

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -34,7 +34,7 @@ class TestProcess(Process):
         assert type(self.messages[0]) == Message
         assert self.inner_member.data == 42
         tmp_value = "SHOULD BE DROPPED"
-        
+
         if msg.type == 'FIRST_STEP':
             # we suppose it will be discarded later
             self.data = tmp_value

--- a/crates/dslab-mp-python/python-tests/process.py
+++ b/crates/dslab-mp-python/python-tests/process.py
@@ -1,12 +1,10 @@
-from dslabmp import Context, Message, Process, StateMember, Serialize
+from dslabmp import Context, Message, Process, StateMember
 
 
 class DataClass:
     def __init__(self, x=42):
         self.data = x
 
-    @staticmethod
-    @Serialize
     def toJSON(self):
         return {'value': self.data}
 

--- a/crates/dslab-mp-python/python/dslabmp.py
+++ b/crates/dslab-mp-python/python/dslabmp.py
@@ -118,10 +118,10 @@ class StateMember:
     @staticmethod
     def _serialize_obj(obj):
         """
-        For custom objects serialization chooses an approach:
-        1. [RECOMMENDED] Any object can specify its serialization to JSON if serialize(self) function is specified.
-        Have a look at DataClass in python-tests/process.py for an example.
-        2. [DEFAULT] Object is saved by its __dict__ representation.
+        Serializes objects using the following approaches:
+        1. Calls `obj.serialize()` method that should return a JSON serializable representation of obj.
+        It is recommended to implement this method for user-defined classes (see the Message class above for example).
+        2. If `serialize` method is not found, resorts to using the `obj.__dict__` representation.
         """
         res = {}
         if hasattr(obj, 'serialize'):
@@ -135,10 +135,12 @@ class StateMember:
     @staticmethod
     def _deserialize_obj(dct):
         """
-        For custom objects deserialization chooses an approach:
-        1. [RECOMMENDED] Any object can specify its deserialization to JSON if deserialize() static function is specified.
-        Have a look at DataClass in python-tests/process.py for an example. 
-        2. [DEFAULT] Object is created from its __dict__ representation through constructor.
+        Deserializes objects using the following approaches:
+        1. Calls `deserialize()` static method of the object's class that should recreate the object from the passed
+        JSON serializable representation. It is recommended to implement this method for user-defined classes
+        (see the Message class above for example).
+        2. If `deserialize()` method is not found, resorts to creating the object from its `__dict__` representation 
+        through constructor.
         """
         if '_module' in dct:
             cls = getattr(sys.modules[dct['_module']], dct['_class'])

--- a/crates/dslab-mp-python/python/dslabmp.py
+++ b/crates/dslab-mp-python/python/dslabmp.py
@@ -7,29 +7,26 @@ from typing import Any, Dict, List, Tuple, Union
 JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
 
 class Message:
-    def __init__(self, message_type: str, data: str):
-        self._type = message_type
-        self._data = json.loads(data)
+    def __init__(self, message_type: str, data: Dict[str, Any]):
+        self.message_type = message_type
+        self.data = data
 
     @property
     def type(self) -> str:
-        return self._type
+        return self.message_type
 
     def __getitem__(self, key: str) -> Any:
-        return self._data[key]
+        return self.data[key]
 
     def __setitem__(self, key: str, value: Any):
-        self._data[key] = value
+        self.data[key] = value
 
     def remove(self, key: str):
-        self._data.pop(key, None)
-
-    def serialize(self):
-        return {"_type": self._type, "_data": json.dumps(self._data)}
+        self.data.pop(key, None)
 
     @staticmethod
-    def deserialize(data):
-        return Message(data['_type'], data['_data'])
+    def from_inner_data(type: str, data: str) -> Message:
+        return Message(type, json.loads(data))
 
 
 class Context(object):
@@ -46,13 +43,13 @@ class Context(object):
         if not isinstance(to, str):
             raise TypeError(
                 'to argument has to be string, not {}'.format(type(to)))
-        self._sent_messages.append((msg.type, json.dumps(msg._data), to))
+        self._sent_messages.append((msg.type, json.dumps(msg.data), to))
 
     def send_local(self, msg: Message):
         """
         Sends a _local_ message.
         """
-        self._sent_local_messages.append((msg.type, json.dumps(msg._data)))
+        self._sent_local_messages.append((msg.type, json.dumps(msg.data)))
 
     def set_timer(self, timer_name: str, delay: float):
         """
@@ -126,7 +123,7 @@ class StateMember:
                 res = getattr(cls, 'deserialize')(dct['data'])
                 return res
             else:
-                return cls(**dct)
+                return cls(**dct['data'])
         return dct
 
     @staticmethod

--- a/crates/dslab-mp-python/python/dslabmp.py
+++ b/crates/dslab-mp-python/python/dslabmp.py
@@ -4,11 +4,9 @@ import json
 import sys
 from typing import Any, Dict, List, Tuple, Union
 
-JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
-
 class Message:
-    def __init__(self, message_type: str, data: Dict[str, Any]):
-        self._type = message_type
+    def __init__(self, type_: str, data: Dict[str, Any]):
+        self._type = type_
         self._data = data
 
     @property
@@ -33,8 +31,8 @@ class Message:
 
 
     @staticmethod
-    def from_inner_data(type: str, data: str) -> Message:
-        return Message(type, json.loads(data))
+    def from_json_str(type_: str, data: str) -> Message:
+        return Message(type_, json.loads(data))
 
 
 class Context(object):
@@ -100,7 +98,7 @@ class Context(object):
 
 
 class StateMember:
-    def __init__(self, t: JSON):
+    def __init__(self, t: Any):
         self.inner = t
 
     def serialize(self) -> str:

--- a/crates/dslab-mp-python/python/dslabmp.py
+++ b/crates/dslab-mp-python/python/dslabmp.py
@@ -22,11 +22,11 @@ class Message:
     def remove(self, key: str):
         self._data.pop(key, None)
 
-    def serialize(self) -> str:
+    def serialize(self) -> Dict[str, Any]:
         return {'message_type': self._type, 'data': self._data}
 
     @staticmethod
-    def deserialize(data: str) -> Message:
+    def deserialize(data: Dict[str, Any]) -> Message:
         return Message(data['message_type'], data['data'])
 
 
@@ -48,13 +48,13 @@ class Context(object):
         """
         if not isinstance(to, str):
             raise TypeError('to argument has to be string, not {}'.format(type(to)))
-        self._sent_messages.append((msg.type, json.dumps(msg.data), to))
+        self._sent_messages.append((msg.type, json.dumps(msg._data), to))
 
     def send_local(self, msg: Message):
         """
         Sends a _local_ message.
         """
-        self._sent_local_messages.append((msg.type, json.dumps(msg.data)))
+        self._sent_local_messages.append((msg.type, json.dumps(msg._data)))
 
     def set_timer(self, timer_name: str, delay: float):
         """

--- a/crates/dslab-mp-python/python/dslabmp.py
+++ b/crates/dslab-mp-python/python/dslabmp.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, List, Tuple, Union
 JSON = Union[Dict[str, "JSON"], List["JSON"], str, int, float, bool, None]
 
 class Message:
-    def __init__(self, message_type: str, data: Dict[str, Any]):
+    def __init__(self, message_type: str, data: str):
         self._type = message_type
-        self._data = data
+        self._data = json.loads(data)
 
     @property
     def type(self) -> str:
@@ -25,7 +25,7 @@ class Message:
         self._data.pop(key, None)
 
     def serialize(self):
-        return {"_type": self._type, "_data": self._data}
+        return {"_type": self._type, "_data": json.dumps(self._data)}
 
     @staticmethod
     def deserialize(data):

--- a/crates/dslab-mp-python/src/lib.rs
+++ b/crates/dslab-mp-python/src/lib.rs
@@ -118,10 +118,9 @@ impl PyProcess {
 impl Process for PyProcess {
     fn on_message(&mut self, msg: Message, from: String, ctx: &mut Context) {
         Python::with_gil(|py| {
-            let args = PyList::new(py, [("_type", msg.tip), ("_data", msg.data)]);
             let py_msg = self
                 .msg_class
-                .call_method1(py, "deserialize", (PyDict::from_sequence(py, args.into()).unwrap(),))
+                .call1(py, (msg.tip, msg.data))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
@@ -135,10 +134,9 @@ impl Process for PyProcess {
 
     fn on_local_message(&mut self, msg: Message, ctx: &mut Context) {
         Python::with_gil(|py| {
-            let args = PyList::new(py, [("_type", msg.tip), ("_data", msg.data)]);
             let py_msg = self
                 .msg_class
-                .call_method1(py, "deserialize", (PyDict::from_sequence(py, args.into()).unwrap(),))
+                .call1(py, (msg.tip, msg.data))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc

--- a/crates/dslab-mp-python/src/lib.rs
+++ b/crates/dslab-mp-python/src/lib.rs
@@ -120,7 +120,7 @@ impl Process for PyProcess {
         Python::with_gil(|py| {
             let py_msg = self
                 .msg_class
-                .call_method1(py, "from_inner_data", (msg.tip, msg.data))
+                .call_method1(py, "from_json_str", (msg.tip, msg.data))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
@@ -136,7 +136,7 @@ impl Process for PyProcess {
         Python::with_gil(|py| {
             let py_msg = self
                 .msg_class
-                .call_method1(py, "from_inner_data", (msg.tip, msg.data))
+                .call_method1(py, "from_json_str", (msg.tip, msg.data))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc

--- a/crates/dslab-mp-python/src/lib.rs
+++ b/crates/dslab-mp-python/src/lib.rs
@@ -121,7 +121,7 @@ impl Process for PyProcess {
             let args = PyList::new(py, [("_type", msg.tip), ("_data", msg.data)]);
             let py_msg = self
                 .msg_class
-                .call_method1(py, "fromJSON", (PyDict::from_sequence(py, args.into()).unwrap(),))
+                .call_method1(py, "deserialize", (PyDict::from_sequence(py, args.into()).unwrap(),))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
@@ -138,7 +138,7 @@ impl Process for PyProcess {
             let args = PyList::new(py, [("_type", msg.tip), ("_data", msg.data)]);
             let py_msg = self
                 .msg_class
-                .call_method1(py, "fromJSON", (PyDict::from_sequence(py, args.into()).unwrap(),))
+                .call_method1(py, "deserialize", (PyDict::from_sequence(py, args.into()).unwrap(),))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc

--- a/crates/dslab-mp-python/src/lib.rs
+++ b/crates/dslab-mp-python/src/lib.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::rc::Rc;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyModule, PyString, PyTuple};
+use pyo3::types::{PyModule, PyString, PyTuple};
 
 use dslab_mp::context::Context;
 use dslab_mp::message::Message;
@@ -118,7 +118,10 @@ impl PyProcess {
 impl Process for PyProcess {
     fn on_message(&mut self, msg: Message, from: String, ctx: &mut Context) {
         Python::with_gil(|py| {
-            let py_msg = self.msg_class.call1(py, (msg.tip, msg.data)).unwrap();
+            let py_msg = self
+                .msg_class
+                .call_method1(py, "from_inner_data", (msg.tip, msg.data))
+                .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
                 .call_method1(py, "on_message", (py_msg, from, &py_ctx))
@@ -131,7 +134,10 @@ impl Process for PyProcess {
 
     fn on_local_message(&mut self, msg: Message, ctx: &mut Context) {
         Python::with_gil(|py| {
-            let py_msg = self.msg_class.call1(py, (msg.tip, msg.data)).unwrap();
+            let py_msg = self
+                .msg_class
+                .call_method1(py, "from_inner_data", (msg.tip, msg.data))
+                .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
                 .call_method1(py, "on_local_message", (py_msg, &py_ctx))

--- a/crates/dslab-mp-python/src/lib.rs
+++ b/crates/dslab-mp-python/src/lib.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::rc::Rc;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyModule, PyString, PyTuple};
+use pyo3::types::{PyDict, PyList, PyModule, PyString, PyTuple};
 
 use dslab_mp::context::Context;
 use dslab_mp::message::Message;
@@ -118,9 +118,10 @@ impl PyProcess {
 impl Process for PyProcess {
     fn on_message(&mut self, msg: Message, from: String, ctx: &mut Context) {
         Python::with_gil(|py| {
+            let args = PyList::new(py, [("_type", msg.tip), ("_data", msg.data)]);
             let py_msg = self
                 .msg_class
-                .call_method1(py, "from_json", (msg.tip, msg.data))
+                .call_method1(py, "fromJSON", (PyDict::from_sequence(py, args.into()).unwrap(),))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
@@ -134,9 +135,10 @@ impl Process for PyProcess {
 
     fn on_local_message(&mut self, msg: Message, ctx: &mut Context) {
         Python::with_gil(|py| {
+            let args = PyList::new(py, [("_type", msg.tip), ("_data", msg.data)]);
             let py_msg = self
                 .msg_class
-                .call_method1(py, "from_json", (msg.tip, msg.data))
+                .call_method1(py, "fromJSON", (PyDict::from_sequence(py, args.into()).unwrap(),))
                 .unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc

--- a/crates/dslab-mp-python/src/lib.rs
+++ b/crates/dslab-mp-python/src/lib.rs
@@ -118,10 +118,7 @@ impl PyProcess {
 impl Process for PyProcess {
     fn on_message(&mut self, msg: Message, from: String, ctx: &mut Context) {
         Python::with_gil(|py| {
-            let py_msg = self
-                .msg_class
-                .call1(py, (msg.tip, msg.data))
-                .unwrap();
+            let py_msg = self.msg_class.call1(py, (msg.tip, msg.data)).unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
                 .call_method1(py, "on_message", (py_msg, from, &py_ctx))
@@ -134,10 +131,7 @@ impl Process for PyProcess {
 
     fn on_local_message(&mut self, msg: Message, ctx: &mut Context) {
         Python::with_gil(|py| {
-            let py_msg = self
-                .msg_class
-                .call1(py, (msg.tip, msg.data))
-                .unwrap();
+            let py_msg = self.msg_class.call1(py, (msg.tip, msg.data)).unwrap();
             let py_ctx = self.ctx_class.call1(py, (ctx.time(),)).unwrap();
             self.proc
                 .call_method1(py, "on_local_message", (py_msg, &py_ctx))

--- a/crates/dslab-mp-python/src/tests.rs
+++ b/crates/dslab-mp-python/src/tests.rs
@@ -18,12 +18,8 @@ fn test_set_state() {
     env::set_var("PYTHONPATH", "python");
     let (mut sys, proc_state) = build_system();
     let data = r#"{"value": "Hello!"}"#;
-    sys.send_local_message("proc", Message::new("echo", data));
+    sys.send_local_message("proc", Message::new("FIRST_STEP", data));
     sys.step_until_no_events();
-
-    // process sends local message only if it has a secret which is not a state member
-    let msgs = sys.read_local_messages("proc");
-    assert_eq!(msgs.len(), 1);
 
     // process should not have anything but state members after `set_state()`
     sys.get_node("node")
@@ -32,8 +28,6 @@ fn test_set_state() {
         .get_process("proc")
         .unwrap()
         .set_state(&proc_state);
-    sys.send_local_message("proc", Message::new("echo", data));
+    sys.send_local_message("proc", Message::new("SECOND_STEP", data));
     sys.step_until_no_events();
-    let msgs = sys.read_local_messages("proc");
-    assert_eq!(msgs.len(), 0);
 }


### PR DESCRIPTION
Ситуация: мы не умеем десериализовать кастомные сообщения (https://levelup.gitconnected.com/how-to-deserialize-json-to-custom-class-objects-in-python-d8b92949cd3b только в виде каких-то стремных структур). От этого страдает, например, возможность добавить StateMember[List[Message]] в решение.

json умеет в object_hook, поэтому мы теперь умеем десериализовать сообщение в любой сложной структуре, а также ассертим студенту, что если он хочет сделать свой кастомный класс в StateMember, то так нельзя

```
!!! Error when calling Python code:

Traceback (most recent call last):
  File "/home/kikos/dev/hse/22-23/diploma/dslab/crates/dslab-mp-python/python/dslabmp.py", line 143, in get_state
    data[name] = member.serialize()
  File "/home/kikos/dev/hse/22-23/diploma/dslab/crates/dslab-mp-python/python/dslabmp.py", line 105, in serialize
    return json.dumps(self.inner, default=assertion_serializable)
  File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/kikos/dev/hse/22-23/diploma/dslab/crates/dslab-mp-python/python/dslabmp.py", line 103, in assertion_serializable
    assert isinstance(o, Message), 'cannot serialize custom classes' 
AssertionError: cannot serialize custom classes

```