### PR TITLE
Reset next event to 0

### DIFF
--- a/crates/dslab-network/src/shared_bandwidth_model.rs
+++ b/crates/dslab-network/src/shared_bandwidth_model.rs
@@ -46,6 +46,8 @@ impl DataOperation for SharedBandwidthNetwork {
         self.throughput_model.pop().unwrap();
         if let Some((time, data)) = self.throughput_model.peek() {
             self.next_event = ctx.emit_self(DataReceive { data: data.clone() }, time - ctx.time());
+        } else {
+            self.next_event = 0;
         }
     }
 


### PR DESCRIPTION
`load_network` возвращает `Rc<Refcell<_>>`, поэтому `clone` на самом деле клонирует указатель на эту сеть, и получается, что используется одна и та же сеть между запусками. Баг проявляется только в случае переиспользования сети, так как в пределах одной симуляции это была бы просто лишняя попытка отмены уже отмененного события, но со сбросом счетчика в новой симуляции это не так.