### PR TITLE
[dag] Fix lookahead bug

### DIFF
--- a/crates/dslab-dag/src/schedulers/lookahead.rs
+++ b/crates/dslab-dag/src/schedulers/lookahead.rs
@@ -60,7 +60,7 @@ impl LookaheadScheduler {
 
         let mut result: Vec<(f64, Action)> = Vec::new();
 
-        for task_id in task_ids.into_iter() {
+        for &task_id in task_ids.iter() {
             let mut best_makespan = f64::MAX;
             let mut best_start = -1.;
             let mut best_finish = -1.;
@@ -117,8 +117,11 @@ impl LookaheadScheduler {
                     ScheduledTask::new(start_time, finish_time, task_id),
                 ));
 
-                let mut unscheduled_tasks = (0..task_count).filter(|&task| !scheduled[task]).collect::<Vec<usize>>();
-                unscheduled_tasks.sort_by(|&a, &b| task_ranks[b].total_cmp(&task_ranks[a]));
+                let unscheduled_tasks = task_ids
+                    .iter()
+                    .cloned()
+                    .filter(|&task| !scheduled[task])
+                    .collect::<Vec<usize>>();
                 let mut makespan = finish_time + output_time;
 
                 for &child in unscheduled_tasks.iter() {
@@ -227,6 +230,7 @@ impl LookaheadScheduler {
                 data_locations.insert(output, resources[best_resource].id);
             }
             task_locations.insert(task_id, resources[best_resource].id);
+            memory_usage[best_resource].add(best_start, best_finish, dag.get_task(task_id).memory);
 
             result.push((
                 best_start,


### PR DESCRIPTION
Сам баг lookahead [здесь](https://github.com/osukhoroslov/dslab/pull/254/commits/e76ff071c7973dcd2b50e54247e2d4444f522c02#diff-b80a254f583169f5bf6159775326403d18047ee91a53c6bb0987768f054842ddR233)
Заодно нашел еще баг в `common.rs`, который приводил к бесконечному циклу --- раньше [здесь](https://github.com/osukhoroslov/dslab/pull/254/commits/e76ff071c7973dcd2b50e54247e2d4444f522c02#diff-7757ce3fd82dd8abc6bdefeee9ae982ac81fc5e4da5e112fdd37a3fcd64a30c0L209) `continue` работало, так как это было внутри `for possible_start in ...`, а сейчас я `possible_start` обновляю руками в конце каждой итерации