### PR TITLE
[mp/mc] add log for mc local message receive

### DIFF
--- a/crates/dslab-mp/src/logger.rs
+++ b/crates/dslab-mp/src/logger.rs
@@ -173,6 +173,9 @@ impl Logger {
             LogEntry::McLocalMessageSent { msg, proc } => {
                 t!(format!("{:>10} >>> {:<10} {:?}", proc, "local", msg).green());
             }
+            LogEntry::McLocalMessageReceived { msg, proc } => {
+                t!(format!("{:>10} <<< {:<10} {:?}", "local", proc, msg).cyan());
+            }
             LogEntry::McMessageSent { msg, src, dest } => {
                 t!(format!("{:>10} --> {:<10} {:?}", src, dest, msg));
             }
@@ -373,6 +376,10 @@ pub enum LogEntry {
     },
     McStarted {},
     McLocalMessageSent {
+        msg: Message,
+        proc: String,
+    },
+    McLocalMessageReceived {
         msg: Message,
         proc: String,
     },

--- a/crates/dslab-mp/src/mc/system.rs
+++ b/crates/dslab-mp/src/mc/system.rs
@@ -73,9 +73,10 @@ impl McSystem {
         let event_time = Self::get_approximate_event_time(self.depth);
         let state_hash = self.get_state_hash();
 
-        self.trace_handler
-            .borrow_mut()
-            .push(LogEntry::McLocalMessageReceived { msg: msg.clone(), proc: proc.clone() });
+        self.trace_handler.borrow_mut().push(LogEntry::McLocalMessageReceived {
+            msg: msg.clone(),
+            proc: proc.clone(),
+        });
         let new_events = self
             .nodes
             .get_mut(&node)

--- a/crates/dslab-mp/src/mc/system.rs
+++ b/crates/dslab-mp/src/mc/system.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use ordered_float::OrderedFloat;
 
+use crate::logger::LogEntry;
 use crate::mc::events::{McEvent, McEventId};
 use crate::mc::network::McNetwork;
 use crate::mc::node::McNode;
@@ -72,6 +73,9 @@ impl McSystem {
         let event_time = Self::get_approximate_event_time(self.depth);
         let state_hash = self.get_state_hash();
 
+        self.trace_handler
+            .borrow_mut()
+            .push(LogEntry::McLocalMessageReceived { msg: msg.clone(), proc: proc.clone() });
         let new_events = self
             .nodes
             .get_mut(&node)


### PR DESCRIPTION
Читал логи для #285 и там, если запускаться через `mc.run_with_change`, нет событий получения локального сообщения