### PR TITLE
Remove unnecessary panic

### DIFF
--- a/crates/dslab-network/src/models/topology_aware.rs
+++ b/crates/dslab-network/src/models/topology_aware.rs
@@ -278,9 +278,6 @@ impl TopologyAwareNetworkModel {
             }
 
             let bandwidth = min_link.get_path_bandwidth();
-            if bandwidth < last_bandwidth - 1e-12 {
-                panic!("{:.20} < {:.20}", bandwidth, last_bandwidth);
-            }
             let bandwidth = bandwidth.max(last_bandwidth);
             last_bandwidth = bandwidth;
             for &transfer_idx in transfers_through_link[min_link_id].iter() {
@@ -355,9 +352,6 @@ impl TopologyAwareNetworkModel {
             }
 
             let bandwidth = min_link.get_path_bandwidth();
-            if bandwidth < last_bandwidth - 1e-12 {
-                panic!("{:.20} < {:.20}", bandwidth, last_bandwidth);
-            }
             let bandwidth = bandwidth.max(last_bandwidth);
             last_bandwidth = bandwidth;
             for &transfer_idx in self.transfers_through_link[min_link_id].iter() {


### PR DESCRIPTION
При запусках с большими bandwidth все-таки срабатывает иногда, примеры с моих запусков:
```
1111.11111111110972160532 < 1111.11111111111108584737
598.29059829059690400754 < 598.29059829059849562327
153.84615384615244693123 < 153.84615384615383959499
```

Это ассерт на проверку корректности был, корректность и так уже проверили достаточно, сейчас только падает из-за точности арифметики