### PR TITLE
Fixed dot parser crash on daggen DAGs

### DIFF
--- a/crates/dslab-dag/src/parsers/dot_parser.rs
+++ b/crates/dslab-dag/src/parsers/dot_parser.rs
@@ -28,7 +28,23 @@ fn parse_params(s: &[char]) -> HashMap<String, String> {
             continue;
         }
         let mid = mid.unwrap();
-        let name = &item[0..mid];
+        let name = if mid == 0 {
+            &item[0..mid]
+        } else {
+            let mut l = 0;
+            let mut r = mid - 1;
+            while l < mid && s[l].is_whitespace() {
+                l += 1;
+            }
+            while r > 0 && s[r].is_whitespace() {
+                r -= 1;
+            }
+            if l == mid {
+                &item[0..0]
+            } else {
+                &item[l..r + 1]
+            }
+        };
         let value = &item[mid + 1..];
         if value.is_empty() || value[0] != '"' || value[value.len() - 1] != '"' {
             continue;


### PR DESCRIPTION
Парсер dot падает на графах, которые сгенерировал daggen. Вот пример такого графа:

<details>
<summary>DAG</summary>

```
// DAG automatically generated by daggen at Sat Jun 15 20:04:39 2024
// ../../../daggen-master/daggen --dot -n 10 --fat 0.3 
digraph G {
  1 [size="19267895000", alpha="0.14"]
  1 -> 2 [size ="536870912"]
  2 [size="68719476736", alpha="0.14"]
  2 -> 3 [size ="134217728"]
  3 [size="28991029248", alpha="0.09"]
  3 -> 4 [size ="75497472"]
  4 [size="82406084400", alpha="0.02"]
  4 -> 5 [size ="134217728"]
  5 [size="1893135536", alpha="0.12"]
  5 -> 6 [size ="33554432"]
  6 [size="231928233984", alpha="0.04"]
  6 -> 7 [size ="301989888"]
  7 [size="27833141284", alpha="0.09"]
  7 -> 8 [size ="33554432"]
  8 [size="11880626744", alpha="0.11"]
  8 -> 9 [size ="679477248"]
  9 [size="297460136896", alpha="0.18"]
  9 -> 10 [size ="536870912"]
  10 [size="242385796979", alpha="0.10"]
}
```

</details>

Происходит это из-за пробела в ключе "size". Я не уверен, что формат разрешает такие пробелы, но хочется всё-таки использовать daggen с симулятором.